### PR TITLE
clarify stacktraces by naming wrapped funcs

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -232,7 +232,7 @@ def mutate(__data, **kwargs):
 
 
 @mutate.register(DataFrameGroupBy)
-def _(__data, **kwargs):
+def _mutate(__data, **kwargs):
     strip_kwargs = {k: strip_symbolic(v) for k,v in kwargs.items()}
     df = __data.apply(lambda d: d.assign(**strip_kwargs))
     
@@ -302,7 +302,7 @@ def filter(__data, *args):
     return __data.loc[crnt_indx,:]
 
 @filter.register(DataFrameGroupBy)
-def _(__data, *args):
+def _filter(__data, *args):
     df_filter = filter.registry[pd.DataFrame]
 
     filtered = __data.apply(df_filter, *args)
@@ -350,7 +350,7 @@ def summarize(__data, **kwargs):
 
     
 @summarize.register(DataFrameGroupBy)
-def _(__data, **kwargs):
+def _summarize(__data, **kwargs):
     df_summarize = summarize.registry[pd.DataFrame]
 
     df = __data.apply(df_summarize, **kwargs)
@@ -378,7 +378,7 @@ def transmute(__data, *args, **kwargs):
     return df[[*arg_vars, *kwargs.keys()]]
 
 @transmute.register(DataFrameGroupBy)
-def _(__data, *args, **kwargs):
+def _transmute(__data, *args, **kwargs):
     # Note: not the most efficient function. Selects columns every group.
     f_transmute = transmute.registry[pd.DataFrame]
 
@@ -528,7 +528,7 @@ def select(__data, *args, **kwargs):
     return __data[list(od)].rename(columns = to_rename)
     
 @select.register(DataFrameGroupBy)
-def _(__data, *args, **kwargs):
+def _select(__data, *args, **kwargs):
     raise Exception("Selecting columns of grouped DataFrame currently not allowed")
 
 
@@ -543,7 +543,7 @@ def rename(__data, **kwargs):
     return __data.rename(columns  = col_names)
 
 @rename.register(DataFrameGroupBy)
-def _(__data, **kwargs):
+def _rename(__data, **kwargs):
     raise Exception("Selecting columns of grouped DataFrame currently not allowed")
 
 
@@ -618,7 +618,7 @@ def distinct(__data, *args, _keep_all = False, **kwargs):
     return tmp_data
         
 @distinct.register(DataFrameGroupBy)
-def _(__data, *args, _keep_all = False, **kwargs):
+def _distinct(__data, *args, _keep_all = False, **kwargs):
     df = __data.apply(lambda x: distinct(x, *args, _keep_all = _keep_all, **kwargs))
     return _regroup(df)
 
@@ -631,11 +631,11 @@ def if_else(__data, *args, **kwargs):
 
 @if_else.register(Call)
 @if_else.register(Symbolic)
-def _(__data, *args, **kwargs):
+def _if_else(__data, *args, **kwargs):
     return create_sym_call(if_else, __data, *args, **kwargs)
 
 @if_else.register(pd.Series)
-def _(cond, true_vals, false_vals):
+def _if_else(cond, true_vals, false_vals):
     true_indx = np.where(cond)[0]
     false_indx = np.where(~cond)[0]
 
@@ -674,7 +674,7 @@ def case_when(__data, cases):
 
 @case_when.register(Symbolic)
 @case_when.register(Call)
-def _(__data, cases):
+def _case_when(__data, cases):
     if not isinstance(cases, dict):
         raise Exception("Cases must be a dictionary")
     dict_entries = dict((strip_symbolic(k), strip_symbolic(v)) for k,v in cases.items())
@@ -795,7 +795,7 @@ def join(left, right, on = None, how = None):
 
 
 @join.register(object)
-def _(left, right, on = None, how = None):
+def _join(left, right, on = None, how = None):
     raise Exception("Unsupported type %s" %type(left))
 
 

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -235,7 +235,7 @@ def collect(__data, as_df = True):
 
 
 @select.register(LazyTbl)
-def _(__data, *args, **kwargs):
+def _select(__data, *args, **kwargs):
     # see https://stackoverflow.com/questions/25914329/rearrange-columns-in-sqlalchemy-select-object
     last_op = __data.last_op
     columns = {c.key: c for c in last_op.inner_columns}
@@ -256,7 +256,7 @@ def _(__data, *args, **kwargs):
 
 
 @filter.register(LazyTbl)
-def _(__data, *args, **kwargs):
+def _filter(__data, *args, **kwargs):
     # TODO: aggregate funcs
     # Note: currently always produces 2 additional select statements,
     #       1 for window/aggs, and 1 for the where clause
@@ -295,7 +295,7 @@ def _(__data, *args, **kwargs):
 
 
 @mutate.register(LazyTbl)
-def _(__data, **kwargs):
+def _mutate(__data, **kwargs):
     # Cases
     #  - work with group by
     #  - window functions
@@ -349,7 +349,7 @@ def _mutate_select(sel, colname, func, labs, __data):
 
 
 @arrange.register(LazyTbl)
-def _(__data, *args):
+def _arrange(__data, *args):
     last_op = __data.last_op
     cols = lift_inner_cols(last_op)
 
@@ -370,7 +370,7 @@ def _(__data, *args):
 
 
 @count.register(LazyTbl)
-def _(__data, *args, sort = False):
+def _count(__data, *args, sort = False):
     # TODO: if already col named n, use name nn, etc.. get logic from tidy.py
     # similar to filter verb, we need two select statements,
     # an inner one for derived cols, and outer to group by them
@@ -417,7 +417,7 @@ def _(__data, *args, sort = False):
 
 
 @summarize.register(LazyTbl)
-def _(__data, **kwargs):
+def _summarize(__data, **kwargs):
     # https://stackoverflow.com/questions/14754994/why-is-sqlalchemy-count-much-slower-than-the-raw-query
     # what if windowed mutate or filter has been done? 
     #   - filter is fine, since it uses a CTE
@@ -459,16 +459,16 @@ def _(__data, **kwargs):
 
 
 @group_by.register(LazyTbl)
-def _(__data, *args):
+def _group_by(__data, *args):
     return __data.copy(group_by = args)
 
 @ungroup.register(LazyTbl)
-def _(__data):
+def _ungroup(__data):
     return __data.copy(group_by = None)
 
 
 @case_when.register(sql.base.ImmutableColumnCollection)
-def _(__data, cases):
+def _case_when(__data, cases):
     # TODO: will need listener to enter case statements, to handle when they use windows
     if isinstance(cases, Call):
         cases = cases(__data)
@@ -523,7 +523,7 @@ def _relabeled_cols(columns, keys, suffix):
 
 
 @join.register(LazyTbl)
-def _(left, right, on = None, how = None):
+def _join(left, right, on = None, how = None):
     # Needs to be on the table, not the select
     left_sel = left.last_op.alias()
     right_sel = right.last_op.alias()
@@ -563,7 +563,7 @@ def _(left, right, on = None, how = None):
 # Head ------------------------------------------------------------------------
 
 @head.register(LazyTbl)
-def _(__data, n = 5):
+def _head(__data, n = 5):
     sel = __data.last_op
     
     return __data.append_op(sel.limit(n))
@@ -572,7 +572,7 @@ def _(__data, n = 5):
 # Rename ----------------------------------------------------------------------
 
 @rename.register(LazyTbl)
-def _(__data, **kwargs):
+def _rename(__data, **kwargs):
     sel = __data.last_op
     columns = lift_inner_cols(sel)
 
@@ -589,7 +589,7 @@ def _(__data, **kwargs):
 # Distinct --------------------------------------------------------------------
 
 @distinct.register(LazyTbl)
-def _(__data, *args, _keep_all = False, **kwargs):
+def _distinct(__data, *args, _keep_all = False, **kwargs):
     if _keep_all:
         raise NotImplementedError("Distinct in sql requires _keep_all = True")
 
@@ -615,7 +615,7 @@ def _(__data, *args, _keep_all = False, **kwargs):
 # if_else ---------------------------------------------------------------------
 
 @if_else.register(sql.elements.ColumnElement)
-def _(cond, true_vals, false_vals):
+def _if_else(cond, true_vals, false_vals):
     whens = [(cond, true_vals)]
     return sql.case(whens, else_ = false_vals)
 


### PR DESCRIPTION
replaces all wrapped funcs that are named using `def _():`, with `def _func_name()`. So mutate now wraps `def _mutate():`