### PR TITLE
Feat pd anti join

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -945,6 +945,10 @@ def join(left, right, on = None, how = None):
     if how is None:
         raise Exception("Must specify how argument")
 
+    # pandas uses outer, but dplyr uses term full
+    if how == "full":
+        how = "outer"
+
     if isinstance(on, Mapping):
         left_on, right_on = zip(*on.items())
         return left.merge(right, how = how, left_on = left_on, right_on = right_on)

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -121,17 +121,26 @@ def test_basic_full_join(backend, df1, df2):
     target = DF1.merge(DF2, on = "ii", how = "outer")
     assert_frame_sort_equal(out, target)
 
-@backend_sql("TODO: pandas - key error?")
 def test_basic_semi_join(backend, df1, df2):
     assert_frame_sort_equal(
             semi_join(df1, df2, {"ii": "ii"}) >> collect(),
             DF1.iloc[:2,]
             )
 
-@backend_sql("TODO: pandas - implement anti join")
 def test_basic_anti_join(backend, df1, df2):
     assert_frame_sort_equal(
             anti_join(df1, df2, on = {"ii": "ii"}) >> collect(),
             DF1.iloc[2:,]
             )
 
+def test_basic_anti_join(backend, df1, df2):
+    assert_frame_sort_equal(
+            anti_join(df1, df2, on = {"ii": "ii"}) >> collect(),
+            DF1.iloc[2:,]
+            )
+
+def test_basic_anti_join(backend, df1, df2):
+    assert_frame_sort_equal(
+            anti_join(df1, df2, on = {"ii": "ii", "x": "y"}) >> collect(),
+            DF1.iloc[2:,]
+            )

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -114,7 +114,6 @@ def test_basic_inner_join(df1, df2):
     target = DF1.iloc[:2,:].assign(y = ["a", "b"])
     assert_frame_sort_equal(out, target)
 
-@backend_sql("TODO: pandas - full should be converted to 'outer'")
 @pytest.mark.skip_backend("sqlite")
 def test_basic_full_join(backend, df1, df2):
     out = full_join(df1, df2, {"ii": "ii"}) >> collect()


### PR DESCRIPTION
* implements pandas anti_join (solves #79)
* fixes semi join including joining columns for right table, when on argument was a mapping (e.g. `semi_join(DF1, DF2, on = {'a': 'b'})` including 'b' column)
* fixes pandas full_join (was expecting the word "outer)