### PR TITLE
fix: pytest skip_backend fixture running too often

### DIFF
--- a/siuba/tests/conftest.py
+++ b/siuba/tests/conftest.py
@@ -16,7 +16,7 @@ params_backend = [
 def backend(request):
     return request.param()
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def skip_backend(request, backend):
     if request.node.get_closest_marker('skip_backend'):
         mark_args = request.node.get_closest_marker('skip_backend').args

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -115,7 +115,7 @@ def test_basic_inner_join(df1, df2):
     assert_frame_sort_equal(out, target)
 
 @pytest.mark.skip_backend("sqlite")
-def test_basic_full_join(backend, df1, df2):
+def test_basic_full_join(skip_backend, backend, df1, df2):
     out = full_join(df1, df2, {"ii": "ii"}) >> collect()
     target = DF1.merge(DF2, on = "ii", how = "outer")
     assert_frame_sort_equal(out, target)


### PR DESCRIPTION
setting autouse = True meant that each test ran three times, once for each backend. However, this means that tests that don't even use backends just are re-run three times :/