### PR TITLE
feat: ShortException error, and shortened sql error stack traces

### DIFF
--- a/siuba/error.py
+++ b/siuba/error.py
@@ -1,0 +1,47 @@
+from contextlib import contextmanager, AbstractContextManager
+import sys
+import copy
+
+ERROR_INSTRUCTIONS = "To see the full error, run: import siuba.error; raise siuba.error.last()"
+
+def last():
+    """Return last error with suppress context set to False.
+    
+    Note: makes a copy of last error, since interactive shells like ipython
+          do later handling of exceptions, so a context manager is not an option.
+
+    """
+
+    err = sys.last_value
+
+    if err is None:
+        return None
+
+    err.__suppress_context__ = False
+    return err
+
+
+class ShortException(Exception):
+    """Exception that provides the option (short) to remove context from stack traces.
+    
+    This greatly shortens the stack. Instructions are provided for viewing the whole thing.
+
+    """
+    def __init__(self, msg, short = False):
+        if short: 
+            full_msg = str(msg) + "\n\n" + ERROR_INSTRUCTIONS
+        else:
+            full_msg = msg
+
+        self.args = (full_msg,)
+        self.__suppress_context__ = short
+
+
+    @classmethod
+    def from_verb(cls, verb_name, arg_name, err, *args, **kwargs):
+        error_msg = "\nVerb: {verb}\nArg: {arg}\nError: {err}.".format(
+                verb = verb_name, arg = arg_name, err = err
+                )
+        
+        return cls(error_msg, *args, **kwargs)
+

--- a/siuba/siu.py
+++ b/siuba/siu.py
@@ -328,6 +328,12 @@ class MetaArg(Call):
         return x
 
 
+# Trees and Visitors ==========================================================
+from .error import ShortException
+
+class FunctionLookupError(ShortException): pass
+
+
 class CallVisitor:
     """
     A node visitor base class that walks the call tree and calls a
@@ -385,8 +391,8 @@ class CallTreeLocal(CallListener):
 
         try:
             local_func = self.local[name]
-        except KeyError:
-            raise Exception("No local entry %s"% name)
+        except KeyError as err:
+            raise FunctionLookupError("Missing translation for function call: %s"% name)
 
 
         return cls(

--- a/siuba/tests/test_error.py
+++ b/siuba/tests/test_error.py
@@ -1,0 +1,41 @@
+from siuba import error
+import sys
+import pytest
+
+
+@pytest.fixture(scope = "function")
+def last_exc():
+    # Note: can't really insert on sys.last_value here, and clean up after...
+    err = error.ShortException("testing", short = True)
+
+    yield err
+
+def test_siuba_error_last(last_exc):
+    # test part
+    assert last_exc.__suppress_context__ is True
+    sys.last_value = last_exc
+    
+    err2 = error.last()
+
+    assert last_exc is err2
+    err2.__suppress_context__ is False
+
+
+def test_siuba_error_shortexception_from_verb():
+
+    err = error.ShortException.from_verb("Mutate", "some_arg_name", "some message", short = True)
+
+    assert "Mutate" in str(err)
+    assert "some_arg_name" in str(err)
+    assert "some message" in str(err)
+
+    assert err.__suppress_context__ is True
+
+    assert error.ERROR_INSTRUCTIONS in str(err)
+
+def test_siuba_error_instruction(last_exc):
+    sys.last_value = last_exc
+    full_error_code = str(last_exc).split(":")[-1].lstrip()
+
+    with pytest.raises(error.ShortException) as err:
+        exec(full_error_code)

--- a/siuba/tests/test_sql_verbs.py
+++ b/siuba/tests/test_sql_verbs.py
@@ -55,6 +55,27 @@ def test_lazy_tbl_manual_columns(db):
     with pytest.raises(AttributeError):
         tbl.tbl.columns.email_address
 
+# SqlFunctionLookupError ------------------------------------------------------
+
+from siuba import _
+from siuba.sql import arrange, filter, mutate, summarize, SqlFunctionLookupError
+from siuba.siu import strip_symbolic
+
+def test_lazy_tbl_shape_call_error(db):
+    tbl = LazyTbl(db, 'addresses')
+
+    call = strip_symbolic(_.id.asdkfjsdf())
+    with pytest.raises(SqlFunctionLookupError) as err:
+        tbl.shape_call(call)
+
+        # suppresses context for shorter stack trace
+        assert err.__suppress_context__ == True
+
+
+
+# TODO: remove these old tests? should be redundant ===========================
+
+
 # mutate ----------------------------------------------------------------------
 
 def test_sql_mutate(db):


### PR DESCRIPTION
The only application so far is removing context from stacktraces, when SQL can't find a function translation:

![image](https://user-images.githubusercontent.com/2574498/64927343-989edf80-d7d7-11e9-932d-fd80d69c59e3.png)

I think we can do some work to shorten the stack traces a bit further, by catching warnings that are for users, rather than developers in the dispatch function, but this is pretty good for now!