### PR TITLE
feat: sql mutate uses fewer CTEs

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -250,7 +250,13 @@ def mutate(__data, **kwargs):
         
     """
     
-    return __data.assign(**kwargs)
+    orig_cols = __data.columns
+    result = __data.assign(**kwargs)
+
+    new_cols = result.columns[~result.columns.isin(orig_cols)]
+
+    return result.loc[:, [*orig_cols, *new_cols]]
+
 
 
 @mutate.register(DataFrameGroupBy)


### PR DESCRIPTION
Addresses #41 

Consolidated with the function col_expr_requires_cte! Now is much better at not creating extra ones :)

```
SELECT anon_1.id, anon_1.user_id, anon_1.email_address, anon_1.id2, anon_1.id2 + 1 AS id3a, anon_1.id2 + 2 AS id3b 
FROM (SELECT addresses.id AS id, addresses.user_id AS user_id, addresses.email_address AS email_address, addresses.id + 1 AS id2 
FROM addresses) AS anon_1
```

This PR passes all tests, but I might look for a few edge cases before merging...