### PR TITLE
Fix spread feature parity

### DIFF
--- a/examples/examples-dplyr-funcs.ipynb
+++ b/examples/examples-dplyr-funcs.ipynb
@@ -505,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -571,7 +571,7 @@
        "3   python  plotnine           0"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1693,7 +1693,7 @@
        "      <td>3500.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
+       "      <th>2</th>\n",
        "      <td>pandas</td>\n",
        "      <td>pandas-dev</td>\n",
        "      <td>1.0</td>\n",
@@ -1701,7 +1701,7 @@
        "      <td>17800.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
+       "      <th>3</th>\n",
        "      <td>plotnine</td>\n",
        "      <td>has2k1</td>\n",
        "      <td>NaN</td>\n",
@@ -1716,8 +1716,8 @@
        "       repo       owner    x     key    value\n",
        "0     dplyr   tidyverse  2.0       R   2800.0\n",
        "1   ggplot2   tidyverse  3.0       R   3500.0\n",
-       "6    pandas  pandas-dev  1.0  python  17800.0\n",
-       "7  plotnine      has2k1  NaN  python   1450.0"
+       "2    pandas  pandas-dev  1.0  python  17800.0\n",
+       "3  plotnine      has2k1  NaN  python   1450.0"
       ]
      },
      "execution_count": 25,
@@ -1930,5 +1930,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -1083,6 +1083,25 @@ def spread(__data, key, value, fill = None, reset_index = True):
     
     return wide
 
+
+@spread.register(DataFrameGroupBy)
+def _spread_gdf(__data, *args, **kwargs):
+
+    groupings = __data.grouper.groupings
+
+    df = __data.obj
+
+    f_spread = spread.registry[pd.DataFrame]
+    out = f_spread(df, *args, **kwargs)
+
+    # regroup, using group names ----
+    group_names = [x.name for x in groupings]
+    if any([name is None for name in group_names]):
+        raise ValueError("spread can only work on grouped DataFrame if all groupings "
+                         "have names. Groups are: %s" %group_names)
+
+    return out.groupby(group_names)
+
 # Expand/Complete ====================================================================
 from pandas.core.reshape.util import cartesian_product
 

--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -1049,7 +1049,7 @@ def gather(__data, key = "key", value = "value", *args, drop_na = False, convert
     long = pd.melt(__data, id_vars, value_vars, key, value)
 
     if drop_na:
-        return long[~long[value].isna()]
+        return long[~long[value].isna()].reset_index(drop = True)
 
     return long
 
@@ -1057,10 +1057,21 @@ def gather(__data, key = "key", value = "value", *args, drop_na = False, convert
 
 # Spread ======================================================================
 
+def _get_single_var_select(columns, x):
+    od = var_select(columns, *var_create(x))
+
+    if len(od) != 1:
+        raise ValueError("Expected single variable, received: %s" %list(od))
+
+    return next(iter(od))
+
 @singledispatch2(pd.DataFrame)
 def spread(__data, key, value, fill = None, reset_index = True):
-    id_cols = [col for col in __data.columns if col not in {key, value}]
-    wide = __data.set_index(id_cols + [key]).unstack(level = -1)
+    key_col = _get_single_var_select(__data.columns, key)
+    val_col = _get_single_var_select(__data.columns, value)
+
+    id_cols = [col for col in __data.columns if col not in (key_col, val_col)]
+    wide = __data.set_index(id_cols + [key_col]).unstack(level = -1)
     
     if fill is not None:
         wide.fillna(fill, inplace = True)

--- a/siuba/tests/test_verb_spread.py
+++ b/siuba/tests/test_verb_spread.py
@@ -1,0 +1,63 @@
+from siuba import spread, gather, _
+from pandas.testing import assert_frame_equal
+import pandas as pd
+
+import pytest
+
+@pytest.fixture
+def df():
+    return pd.DataFrame({
+        'id': [1, 1, 2],
+        'm': ['a', 'b', 'b'],
+        'v': [1,2,3]
+        })
+
+@pytest.fixture
+def wide_df():
+    return pd.DataFrame({
+        'id': [1,2],
+        'a': [1, None],
+        'b': [2., 3.]
+        })
+
+
+@pytest.mark.parametrize('key, value', [
+    ("m", "v"),
+    (_.m, _.v),
+    (_["m"], _["v"]),
+    (1, 2),
+    ])
+def test_spread_selection(df, wide_df, key, value):
+    res = spread(df, key, value)
+
+
+    assert_frame_equal(res, wide_df)
+    
+
+def test_spread_fill(df, wide_df):
+    res = spread(df, "m", "v", fill = 99)
+
+
+def test_gather(df, wide_df):
+    res = gather(wide_df, "m", "v", "a", "b") 
+
+    # note, unlike df, includes an NA now
+    long = pd.DataFrame({
+        'id': [1,2,1,2],
+        'm': ['a', 'a', 'b', 'b'],
+        'v': [1, None, 2, 3]
+        })
+
+    assert_frame_equal(res, long)
+
+def test_gather_drop_na(df, wide_df):
+    res = gather(wide_df, "m", "v", "a", "b", drop_na = True) 
+
+    # note that .dropna doesn't work here, since coerces floats to ints
+    assert_frame_equal(res, df.assign(v = df.v.astype(float)))
+
+def test_gather_drop_na_varselect(df, wide_df):
+    res = gather(wide_df, "m", "v", _["a": "b"], drop_na = True) 
+
+    # note that .dropna doesn't work here, since coerces floats to ints
+    assert_frame_equal(res, df.assign(v = df.v.astype(float)))

--- a/siuba/tests/test_verb_spread.py
+++ b/siuba/tests/test_verb_spread.py
@@ -37,6 +37,19 @@ def test_spread_selection(df, wide_df, key, value):
 def test_spread_fill(df, wide_df):
     res = spread(df, "m", "v", fill = 99)
 
+    assert_frame_equal(res, wide_df.fillna(99.))
+
+
+def test_spread_grouped_df(df, wide_df):
+    gdf = df.groupby('id')
+    res = spread(gdf, "m", "v")
+
+    gdf_wide = wide_df.groupby('id')
+    assert_frame_equal(res.obj, gdf_wide.obj)
+
+    assert len(res.grouper.groupings) == 1
+    assert res.grouper.groupings[0].name == "id"
+
 
 def test_gather(df, wide_df):
     res = gather(wide_df, "m", "v", "a", "b") 
@@ -50,14 +63,17 @@ def test_gather(df, wide_df):
 
     assert_frame_equal(res, long)
 
+
 def test_gather_drop_na(df, wide_df):
     res = gather(wide_df, "m", "v", "a", "b", drop_na = True) 
 
     # note that .dropna doesn't work here, since coerces floats to ints
     assert_frame_equal(res, df.assign(v = df.v.astype(float)))
 
+
 def test_gather_drop_na_varselect(df, wide_df):
     res = gather(wide_df, "m", "v", _["a": "b"], drop_na = True) 
 
     # note that .dropna doesn't work here, since coerces floats to ints
     assert_frame_equal(res, df.assign(v = df.v.astype(float)))
+


### PR DESCRIPTION
addresses 

* #88 - allow var select style arguments (e.g. _.column_name)
* #89 - spread can take a grouped data frame