### PR TITLE
fix: pandas arrange, filter now always resets index

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -99,7 +99,8 @@ def simple_varname(call):
         return call
 
     # check for expr like _.some_var or _["some_var"]
-    if (call.func in {"__getitem__", "__getattr__"}
+    if (isinstance(call, Call)
+        and call.func in {"__getitem__", "__getattr__"}
         and isinstance(call.args[0], MetaArg)
         and isinstance(call.args[1], str)
         ):
@@ -323,9 +324,11 @@ def filter(__data, *args):
     # and iloc can't use a boolean series
     if isinstance(crnt_indx, bool) or isinstance(crnt_indx, np.bool_):
         # iloc can do slice, but not a bool series
-        return __data.iloc[slice(None) if crnt_indx else slice(0),:]
+        result = __data.iloc[slice(None) if crnt_indx else slice(0),:]
+    else:
+        result = __data.loc[crnt_indx,:]
 
-    return __data.loc[crnt_indx,:]
+    return result.reset_index(drop = True)
 
 @filter.register(DataFrameGroupBy)
 def _filter(__data, *args):

--- a/siuba/tests/test_dply_verbs.py
+++ b/siuba/tests/test_dply_verbs.py
@@ -1,5 +1,9 @@
+"""
+This file is for pandas specific verb operations.
+"""
+
 import pytest
-from siuba.dply.verbs import mutate
+from siuba.dply.verbs import mutate, arrange, filter
 from siuba.siu import _
 
 import pandas as pd
@@ -14,6 +18,25 @@ def df1():
         "stars": [17800, 2800, 3500, 1450],
         "x": [1,2,3,None]
         })
+
+
+# verify indexes are reset ----
+
+@pytest.mark.parametrize('f, expr', [
+    (filter, lambda d: d.x < 2),
+    (arrange, lambda d: -d.x)
+    ])
+def test_verb_accepts_non_range_indexing(df1, f, expr):
+    tmp_df = df1.copy()
+    tmp_df.index = [4,3,2,1]
+
+    res1 = f(tmp_df, expr)
+    res2 = f(df1, expr)
+
+    assert_frame_equal(res1, res2)
+
+
+# mutate ------
 
 def test_dply_mutate(df1):
     op_stars_1k = lambda d: d.stars * 1000


### PR DESCRIPTION
In addition tests, that arrange resets index (which was already implemented), so addresses #85