### PR TITLE
Fast mutate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Vim Swapfiles
 .*.swp
+.*.swo
+
+# Temporary folder for experimenting with things
+tmp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	pytest --dbs="sqlite,postgresql" siuba/
 
 test-travis:
-	py.test --nbval $(filter-out %postgres.ipynb, $(NOTEBOOK_TESTS))
+	#py.test --nbval $(filter-out %postgres.ipynb, $(NOTEBOOK_TESTS))
 	pytest --dbs="sqlite,postgresql" siuba/
 
 examples/%.ipynb:

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -6,4 +6,5 @@ Developer docs
 
     call_trees.Rmd
     sql-translators.ipynb
+    pandas-group-ops.Rmd
 

--- a/docs/developer/pandas-group-ops.Rmd
+++ b/docs/developer/pandas-group-ops.Rmd
@@ -1,0 +1,117 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .Rmd
+      format_name: rmarkdown
+      format_version: '1.1'
+      jupytext_version: 1.2.4
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+---
+
+# Optimized grouped pandas operations
+
+```{python}
+import numpy as np
+import pandas as pd
+
+np.random.seed(123)
+students = pd.DataFrame({
+    'student_id': np.repeat(np.arange(2000), 10),
+    'course_id': np.random.randint(1, 20, 20000),
+    'score': np.random.randint(1, 100, 20000)
+})
+
+g_students = students.groupby('student_id')
+```
+
+# Problem: combining grouped operations is slow
+
+If you just need to make a single calculation, then pandas methods are very fast. For example, take the code below, which calculates the minimum score for each student.
+
+```{python}
+# %%timeit
+g_students.score.min()
+```
+
+This took very little time (less than a millisecond, which is 1 thousandth of a second!).
+
+However, now suppose you wanted to do something more complex. Let's say you wanted to get rows corresponding to each students minimum score. In pandas, there are two ways to do this: 
+
+* transform with a lambda
+* by using both the `students` and `g_student` data frames.
+
+These are shown below.
+
+```{python}
+# %%timeit
+is_student_min = g_students.score.transform(lambda x: x == x.min())
+df_min1 = students[is_student_min]
+```
+
+```{python}
+# %%timeit
+is_student_min = students.score == g_students.score.transform('min')
+df_min2 = students[is_student_min]
+```
+
+Note that while the first one could be expressed using only the grouped data (`g_student`), it took over a second to run!
+
+On the other hand, while the other was fairly quick, it required juggling two forms of the data.
+
+Siuba attempts to optimize these operations to be quick AND require less data juggling.
+
+
+## Siuba filtering is succinct AND performant
+
+```{python}
+from siuba.experimental.pd_groups import fast_mutate, fast_filter, fast_summarize
+from siuba import _
+```
+
+```{python}
+# %%timeit
+df_min3 = fast_filter(g_students, _.score == _.score.min())
+```
+
+```{python}
+# %%timeit
+fast_mutate(students, is_low_score = _.score == _.score.min())
+```
+
+```{python}
+# %%timeit
+fast_summarize(g_students, lowest_percent = _.score.min() / 100.)
+```
+
+## How do the optimizations work?
+
+Siuba replaces important parts of the call tree--like `==` and `score()`--with functions that take a grouped series and return a grouped series. Because it then becomes grouped series all the way down, these operations are nicely composable.
+
+```{python}
+_.score == _.score.min()
+```
+
+
+After the expressions are executed, the verb in charge handles the output. For example, `fast_filter` uses the result (usually a boolean Series) to keep only rows where the result is True.
+
+An example is shown below, for how siuba replaces the "mean" function.
+
+```{python}
+from siuba.experimental.pd_groups.translate import method_agg_op
+
+f_mean = method_agg_op('mean', False, None)
+
+# result is a subclass of SeriesGroupBy
+res_agg = f_mean(g_students.score)
+
+print(res_agg)
+print(res_agg.obj.head())
+```
+
+## Defining custom grouped operations
+
+TODO: coming soon

--- a/docs/developer/pandas-group-ops.Rmd
+++ b/docs/developer/pandas-group-ops.Rmd
@@ -28,7 +28,7 @@ students = pd.DataFrame({
 g_students = students.groupby('student_id')
 ```
 
-# Problem: combining grouped operations is slow
+## Problem: combining grouped operations is slow
 
 If you just need to make a single calculation, then pandas methods are very fast. For example, take the code below, which calculates the minimum score for each student.
 

--- a/docs/developer/sql-translators.ipynb
+++ b/docs/developer/sql-translators.ipynb
@@ -194,7 +194,6 @@
     "\n",
     "call_shaper = CallTreeLocal(\n",
     "    local_funcs,\n",
-    "    rm_attr = ('str', 'dt'),\n",
     "    call_sub_attr = ('dt',)\n",
     "    )"
    ]
@@ -352,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,
@@ -369,5 +368,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/architecture/003-fast-mutate.ipynb
+++ b/examples/architecture/003-fast-mutate.ipynb
@@ -1,0 +1,491 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pandas fast mutate architecture"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Problem: series operations are type invariant under grouping\n",
+    "\n",
+    "### What is type variance?\n",
+    "\n",
+    "In spirit, most pandas operations are one of two functions.\n",
+    "\n",
+    "* f_elwise(a, [b]) - takes up to two series, returns a result of the same length.\n",
+    "* f_agg(a, [b]) - takes up to two series, returns a result whose length is the number of groupings in the data.\n",
+    "\n",
+    "Assuming that a SeriesGroupBy was built as a subtype of a Series object,\n",
+    "in the [Liskov Substitution sense](https://en.wikipedia.org/wiki/Liskov_substitution_principle),\n",
+    "this would mean that..\n",
+    "\n",
+    "* `f_elwise(SeriesGroupBy, SeriesGroupBy) -> Series`\n",
+    "\n",
+    "could easily support versions that are...\n",
+    "\n",
+    "* contravariant on input type - e.g. `f_elwise(Series, \"\") -> \"\"`\n",
+    "* covariant on output type - e.g. `f_elwise(\"\", \"\") -> SeriesGroupBy`\n",
+    "\n",
+    "This would be extremely convenient, since it means that defining a function like `f_add = f_elwise(...)`, would support all operations in the python code below...\n",
+    "\n",
+    "```python\n",
+    "from siuba.data import mtcars\n",
+    "\n",
+    "g_cyl = mtcars.groupby('cyl')\n",
+    "\n",
+    "# assume this creates the function f_add\n",
+    "f_add = f_elwise('add')\n",
+    "\n",
+    "mpg2 = f_add(mtcars.mpg, mtcars.mpg)     # -> Series\n",
+    "g_cyl_mpg2 = f_add(g_cyl.mpg, g_cyl.mpg) # -> SeriesGroupBy\n",
+    "```\n",
+    "\n",
+    "### What does this look like in pandas?\n",
+    "\n",
+    "The reality is that pandas SeriesGroupBy objects are not subtypes of a Series.\n",
+    "More than that, they do not support addition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "unsupported operand type(s) for +: 'SeriesGroupBy' and 'SeriesGroupBy'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-b2b9d78e502f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;31m## Both snippets below raise an error.... :/\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m \u001b[0mg_cyl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmpg\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mg_cyl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmpg\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     12\u001b[0m \u001b[0mg_cyl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madd\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mg_cyl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmpg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: unsupported operand type(s) for +: 'SeriesGroupBy' and 'SeriesGroupBy'"
+     ]
+    }
+   ],
+   "source": [
+    "%%capture\n",
+    "import pandas as pd\n",
+    "\n",
+    "pd.set_option(\"display.max_rows\", 5)\n",
+    "\n",
+    "from siuba import _\n",
+    "from siuba.data import mtcars\n",
+    "\n",
+    "g_cyl = mtcars.groupby(\"cyl\")\n",
+    "\n",
+    "## Both snippets below raise an error.... :/\n",
+    "g_cyl.mpg + g_cyl.mpg\n",
+    "g_cyl.add(g_cyl.mpg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How are grouped operations currently handled in pandas?\n",
+    "\n",
+    "* f_elwise(a, [b]) - is handled using ungrouped pandas object (e.g. Series), or by using the grouped series `.obj` attribute.\n",
+    "* f_agg(a, [b]) - is handled using custom SeriesGroupBy methods\n",
+    "\n",
+    "This is shown below (note that all results are Series)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cyl\n",
+       "4    26.663636\n",
+       "6    19.742857\n",
+       "8    15.100000\n",
+       "Name: mpg, dtype: float64"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# two ways to do it f_elwise\n",
+    "ser_mpg2 = mtcars.mpg + mtcars.mpg\n",
+    "ser_mpg2 = g_cyl.mpg.obj + g_cyl.mpg.obj\n",
+    "\n",
+    "# doing grouped aggregate\n",
+    "g_cyl.mpg.mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What about composing f_elwise and f_agg operations?\n",
+    "\n",
+    "Let's take this in two steps\n",
+    "\n",
+    "1. composing `f_elwise` operations alone\n",
+    "2. composing them with f_agg operations\n",
+    "\n",
+    "### 1) `f_elwise(a, f_elwise(b, [c]))`\n",
+    "\n",
+    "In this case, since the result could be a Series, or a SeriesGroupBy,\n",
+    "it shouldn't be a problem.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     43.0\n",
+       "1     43.0\n",
+       "      ... \n",
+       "30    31.0\n",
+       "31    43.8\n",
+       "Name: mpg, Length: 32, dtype: float64"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "degroup = lambda ser: getattr(ser, \"obj\", ser)\n",
+    "f_add = lambda x, y: degroup(x) + degroup(y)\n",
+    "\n",
+    "f_add(g_cyl.mpg, f_add(g_cyl.mpg, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, as noted in the first section, we are returning a Series here, but functions returning a SeriesGroupBy should also be compatible (so long as we enforce liskov substitution..).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2) `f_elwise(f_agg(a), f_agg(b)) -> same length result`\n",
+    "\n",
+    "Suppose we wanted to add the mean `mpg` of each group, to each row of `mpg` in the original data.\n",
+    "\n",
+    "In our system written above, this would look like...\n",
+    "\n",
+    "```python\n",
+    "f_mean = f_agg('mean')\n",
+    "f_add = f_elwise('add')\n",
+    "\n",
+    "res = f_add(g_cyl.mpg, f_mean(g_cyl.mpg))\n",
+    "```\n",
+    "\n",
+    "Remember that for `f_add`, we laid out in the first section that it should allow functions to be substituted in that take a SeriesGroupBy (or parent type) and returns a Series (or subtype)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     142.028571\n",
+       "1     142.028571\n",
+       "         ...    \n",
+       "30    224.314286\n",
+       "31    109.300000\n",
+       "Length: 32, dtype: float64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pandas.core import algorithms\n",
+    "\n",
+    "\n",
+    "def broadcast_agg_result(grouper, result, obj):\n",
+    "    # Simplified broadcasting from g_cyl.mpg.transform('mean')\n",
+    "    ids, _, ngroup = grouper.group_info\n",
+    "    out = algorithms.take_1d(result._values, ids)\n",
+    "\n",
+    "    return pd.Series(out, index=obj.index, name=obj.name)\n",
+    "\n",
+    "\n",
+    "f_mean = lambda x: broadcast_agg_result(x.grouper, x.mean(), degroup(x))\n",
+    "\n",
+    "f_add(f_mean(g_cyl.mpg), f_mean(g_cyl.hp))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice we can keep going with this, since\n",
+    "\n",
+    "* f_add(SeriesGroupBy, SeriesGroupby) -> Series\n",
+    "* f_mean(SeriesGroupBy, SeriesGroupby) -> Series\n",
+    "* we are making SeriesGroupBy a subtype of Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     163.028571\n",
+       "1     163.028571\n",
+       "         ...    \n",
+       "30    239.314286\n",
+       "31    130.700000\n",
+       "Length: 32, dtype: float64"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f_add(g_cyl.mpg, f_add(f_mean(g_cyl.mpg), f_mean(g_cyl.hp)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, there is are two problems here...\n",
+    "\n",
+    "1. adding two means, or a number to a mean, shouldn't need to broadcast to the length of the data\n",
+    "2. in the code above, f_mean(Series) will return a single value (e.g. 1.2)!\n",
+    "\n",
+    "The main issue is that a Series is implicitly a single group. To get around this, f_elwise should decide when to broadcast, and all operations should return SeriesGroupBy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3) `f_elwise(f_agg(a), f_agg(b)) -> agg length result`\n",
+    "\n",
+    "Above, we had the aggregate return a result the same length as the original data. But this goes against our initial description that f_agg returns a result whose length is the number of groupings.\n",
+    "\n",
+    "In this case, we need to think more about f_agg's type signature.\n",
+    "To do this let's consider a new type, `AggGroupBy`, where...\n",
+    "\n",
+    "* `AggGroupBy` is a subtype of `SeriesGroupBy`\n",
+    "* `AggGroupBy` has 1 row per grouping.\n",
+    "* f_agg(a, [b]), with type signature f_agg(`SeriesGroupBy`) -> `AggGroupBy`\n",
+    "\n",
+    "Finally let's make this drastically simplifying requirement\n",
+    "\n",
+    "* any operation must take as input either the output of another operation, a literal, or a series using the same grouping.\n",
+    "\n",
+    "This means that if our operations return grouped Series, then we don't need to worry about the Series case any more. For example, under this system these operations are allowed...\n",
+    "\n",
+    "* `f_agg(g_cyl.mpg)`\n",
+    "* `f_elwise(g_cyl.mpg, 1)`\n",
+    "* `f_elwise(f_agg(g_cyl.mpg), g_cyl.mpg)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pandas.core.groupby import SeriesGroupBy\n",
+    "from pandas.core import algorithms\n",
+    "\n",
+    "\n",
+    "# Define Agg Result ----\n",
+    "def create_agg_result(ser, orig_object, orig_grouper):\n",
+    "    # since pandas groupby method is hard-coded to create a SeriesGroupBy, mock\n",
+    "    # AggResult below by making it a SeriesGroupBy whose grouper has 2 extra attributes\n",
+    "    obj = ser.groupby(ser.index)\n",
+    "    obj.grouper.orig_grouper = orig_grouper\n",
+    "    obj.grouper.orig_object = orig_object\n",
+    "    return obj\n",
+    "\n",
+    "\n",
+    "def is_agg_result(x):\n",
+    "    return hasattr(x, \"grouper\") and hasattr(x.grouper, \"orig_grouper\")\n",
+    "\n",
+    "\n",
+    "# Handling Grouped Operations ----\n",
+    "\n",
+    "\n",
+    "def regroup(ser, grouper):\n",
+    "    return ser.groupby(grouper)\n",
+    "\n",
+    "\n",
+    "def degroup(ser):\n",
+    "    # returns tuple of (Series or literal, Grouper or None)\n",
+    "    # because we can't rely on type checking, use hasattr instead\n",
+    "    return getattr(ser, \"obj\", ser), getattr(ser, \"grouper\", None)\n",
+    "\n",
+    "\n",
+    "def f_mean(x):\n",
+    "    # SeriesGroupBy -> AggResult\n",
+    "    return create_agg_result(x.mean(), x.obj, x.grouper)\n",
+    "\n",
+    "\n",
+    "def broadcast_agg_result(g_ser, compare=None):\n",
+    "    \"\"\"Returns a tuple of (Series, final op grouper)\"\"\"\n",
+    "    if not isinstance(g_ser, SeriesGroupBy):\n",
+    "        return g_ser, compare.grouper\n",
+    "    # NOTE: now only applying for agg_result\n",
+    "    if not is_agg_result(g_ser):\n",
+    "        return degroup(g_ser)\n",
+    "\n",
+    "    if g_ser.grouper.orig_grouper is compare.grouper:\n",
+    "        orig = g_ser.grouper.orig_object\n",
+    "        grouper = g_ser.grouper.orig_grouper\n",
+    "\n",
+    "        # Simplified broadcasting from g_cyl.mpg.transform('mean') implementation\n",
+    "        ids, _, ngroup = grouper.group_info\n",
+    "        out = algorithms.take_1d(g_ser.obj._values, ids)\n",
+    "\n",
+    "        return pd.Series(out, index=orig.index, name=orig.name), grouper\n",
+    "\n",
+    "    return degroup(g_ser)\n",
+    "\n",
+    "\n",
+    "# Define operations ----\n",
+    "\n",
+    "\n",
+    "def f_add(x, y):\n",
+    "    # SeriesGroupBy, SeriesGroupBy -> \"\"\n",
+    "    broad_x, grouper = broadcast_agg_result(x, y)\n",
+    "    broad_y, __ = broadcast_agg_result(y, x)\n",
+    "\n",
+    "    res = broad_x + broad_y\n",
+    "    return regroup(res, grouper)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cyl\n",
+       "4    109.300000\n",
+       "6    142.028571\n",
+       "8    224.314286\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grouped_agg = f_add(f_mean(g_cyl.mpg), f_mean(g_cyl.hp))\n",
+    "\n",
+    "# Notice, only 1 result per group\n",
+    "grouped_agg.obj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     163.028571\n",
+       "1     163.028571\n",
+       "         ...    \n",
+       "30    239.314286\n",
+       "31    130.700000\n",
+       "Name: mpg, Length: 32, dtype: float64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grouped_mutate = f_add(g_cyl.mpg, grouped_agg)\n",
+    "\n",
+    "grouped_mutate.obj"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Decisions\n",
+    "\n",
+    "Functions should essentially follow...\n",
+    "\n",
+    "* f_elwise(SeriesGroupBy, ...) -> SeriesGroupBy\n",
+    "* f_agg(SeriesGroupBy, ...) -> AggGroupBy\n",
+    "\n",
+    "We can use a final method at the end to validate, depending on if it's a mutate, summarize, or filter.\n",
+    "\n",
+    "Additionally...\n",
+    "\n",
+    "* methods on grouped objects can be simply wrapped to keep LSP over functions (since they have some hard-coded constructors)\n",
+    "* I need to investigate ops involving getting dim 0 properties (e.g. dtype)\n",
+    "* need a strategy for keeping user-defined, custom groupby ops\n",
+    "\n",
+    "## Limitations\n",
+    "\n",
+    "* this considers a closed system of function calls, but right now siu expressions can include things like `__getitem__` etc.."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,Rmd"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/siuba/experimental/pd_groups/__init__.py
+++ b/siuba/experimental/pd_groups/__init__.py
@@ -1,0 +1,1 @@
+from .dialect import fast_mutate, fast_filter, fast_summarize

--- a/siuba/experimental/pd_groups/dialect.py
+++ b/siuba/experimental/pd_groups/dialect.py
@@ -20,7 +20,6 @@ for name, entry in spec.items():
 
 call_listener = CallTreeLocal(
         out,
-        rm_attr = ('str', 'dt', 'cat'),
         call_sub_attr = ('str', 'dt', 'cat'),
         chain_sub_attr = True
         )

--- a/siuba/experimental/pd_groups/dialect.py
+++ b/siuba/experimental/pd_groups/dialect.py
@@ -1,0 +1,106 @@
+from siuba.spec.series import spec
+from siuba.siu import CallTreeLocal
+
+from siuba.experimental.pd_groups.translate import SeriesGroupBy, GroupByAgg, GROUP_METHODS
+
+
+# TODO: make into CallTreeLocal factory function
+
+out = {}
+for name, entry in spec.items():
+    #if entry['result']['type']: continue
+        
+    key = (entry['result']['type'], entry['data_arity'])
+    meth = GROUP_METHODS[key]
+    out[name] = meth(
+            name = name.split('.')[-1],
+            is_property = entry['is_property'],
+            accessor = entry['accessor']
+            )
+
+call_listener = CallTreeLocal(
+        out,
+        rm_attr = ('str', 'dt', 'cat'),
+        call_sub_attr = ('str', 'dt', 'cat'),
+        chain_sub_attr = True
+        )
+
+
+# Fast group by verbs =========================================================
+
+from siuba.siu import Call
+from siuba.dply.verbs import mutate, filter, summarize, singledispatch2, DataFrameGroupBy, _regroup
+
+def grouped_eval(__data, expr):
+    if isinstance(expr, Call):
+        call = call_listener.enter(expr)
+
+        #
+        grouped_res = call(__data)
+        if isinstance(grouped_res, GroupByAgg):
+            res = grouped_res._broadcast_agg_result()
+        elif isinstance(grouped_res, SeriesGroupBy):
+            res = grouped_res.obj
+        else:
+            # can happen right now if user selects, e.g., a property of the
+            # groupby object, like .dtype, which returns a single value
+            # in the future, could restrict set of operations user could perform
+            raise ValueError("Result must be subclass of SeriesGroupBy")
+
+    # TODO: for non-call arguments, need to validate they're "literals"
+    return res
+
+
+# Fast mutate ----
+
+@singledispatch2(DataFrameGroupBy)
+def fast_mutate(__data, **kwargs):
+    """Warning: this function is experimental"""
+    out = __data.obj.copy()
+    groupings = __data.grouper.groupings
+
+    for name, expr in kwargs.items():
+        res = grouped_eval(__data, expr)
+        out[name] = res
+
+    return out.groupby(groupings)
+
+
+@fast_mutate.register(object)
+def _fast_mutate_default(__data, **kwargs):
+    # TODO: had to register object second, since singledispatch2 sets object dispatch
+    #       to be a pipe (e.g. unknown types become a pipe by default)
+    # by default dispatch to regular mutate
+    f = mutate.registry[type(__data)]
+    return f(__data, **kwargs)
+
+
+# Fast filter ----
+
+@singledispatch2(DataFrameGroupBy)
+def fast_filter(__data, *args):
+    """Warning: this function is experimental"""
+    import pandas as pd
+    out = []
+    groupings = __data.grouper.groupings
+
+    for expr in args:
+        res = grouped_eval(__data, expr)
+        out.append(res)
+
+    filter_df = filter.registry[pd.DataFrame]
+
+    df_result = filter_df(__data.obj, *out)
+
+    # TODO: research how to efficiently & robustly subset groupings
+    group_names = [ping.name for ping in groupings]
+    return df_result.groupby(group_names)
+
+
+@fast_filter.register(object)
+def _fast_filter_default(__data, *args, **kwargs):
+    # TODO: had to register object second, since singledispatch2 sets object dispatch
+    #       to be a pipe (e.g. unknown types become a pipe by default)
+    # by default dispatch to regular mutate
+    f = filter.registry[type(__data)]
+    return f(__data, *args, **kwargs)

--- a/siuba/experimental/pd_groups/groupby.py
+++ b/siuba/experimental/pd_groups/groupby.py
@@ -1,0 +1,104 @@
+from pandas.core.groupby import DataFrameGroupBy, SeriesGroupBy
+import inspect
+from pandas.core import algorithms
+import pandas as pd
+
+
+# Custom SeriesGroupBy class ==================================================
+
+class GroupByAgg(SeriesGroupBy):
+    def __init__(self, *args, orig_grouper, orig_obj, should_cast, **kwargs):
+        self._orig_grouper = orig_grouper
+        self._orig_obj = orig_obj
+        self._should_cast = should_cast
+        super().__init__(*args, **kwargs)
+    
+    def _broadcast_agg_result(self):
+        return broadcast_agg_result(
+            self._orig_grouper, 
+            self.obj,
+            self._orig_obj,
+            cast = self._should_cast
+        )
+    
+    @classmethod
+    def from_result(cls, result, groupby):
+        if not isinstance(result, pd.Series):
+            raise TypeError("requires pandas Series")
+
+        # Series.groupby is hard-coded to produce a SeriesGroupBy,
+        # but it's signature is very large, so use inspect to bind on it.
+        sig = inspect.signature(result.groupby)
+        bound = sig.bind(by = result.index)
+        
+        orig_grouper = groupby._orig_grouper if isinstance(groupby, cls) else groupby.grouper
+        orig_obj = groupby._orig_obj if isinstance(groupby, cls) else groupby.obj
+        should_cast = False
+        
+        return cls(
+            result,
+            *bound.args, **bound.kwargs,
+            orig_grouper = orig_grouper,
+            orig_obj = orig_obj,
+            should_cast = should_cast
+            )
+
+def broadcast_agg_result(grouper, result, obj, cast = False):
+    """
+    fast version of transform, only applicable to
+    builtin/cythonizable functions
+    """
+    ids, _, ngroup = grouper.group_info
+    out = algorithms.take_1d(result._values, ids)
+    
+    # TODO: consequence of skipping this step? A cast is already done
+    # once when aggregating....
+    if cast:
+        out = try_cast(out, obj)
+    return pd.Series(out, index=obj.index, name=obj.name)
+
+
+# Utils =======================================================================
+
+def all_isinstance(cls, *args):
+    return all(isinstance(x, cls) for x in args)
+
+def _regroup(res, groupby):
+    if isinstance(groupby, GroupByAgg):
+        # need to manually a constructor, since Series classes are hardcoded
+        # all over the pandas library :/ :/ :/
+        return groupby.from_result(res, groupby)
+    elif isinstance(groupby, SeriesGroupBy):
+        return res.groupby(groupby.grouper)
+    
+    raise ValueError("Unknown group by class: %s"% type(groupby))
+
+
+# Broadcasting Groupby elements -----------------------------------------------
+
+def grouper_match(grp1, grp2):
+    if not isinstance(grp2, SeriesGroupBy):
+        raise TypeError("grp2 must be a SeriesGroupBy")
+
+    if grp1._orig_grouper is not grp2.grouper:
+        raise ValueError("groups must match")
+
+    return grp1._broadcast_agg_result(), grp2.obj, grp2
+    
+
+def broadcast_group_elements(x, y):
+    if all_isinstance(GroupByAgg, x, y) and x._orig_grouper is y._orig_grouper:
+        return x.obj, y.obj, x
+    
+    elif isinstance(x, GroupByAgg):
+        return grouper_match(x, y)
+    
+    elif isinstance(y, GroupByAgg):
+        res_y, res_x, grp = grouper_match(y, x)
+        return res_x, res_y, grp
+    
+    elif all_isinstance(SeriesGroupBy, x, y) and x.grouper is y.grouper:
+        return x.obj, y.obj, x
+
+    raise ValueError("need groupby objects with matching groupers")
+

--- a/siuba/experimental/pd_groups/test_pd_groups.py
+++ b/siuba/experimental/pd_groups/test_pd_groups.py
@@ -1,0 +1,92 @@
+import pytest
+from siuba.tests.helpers import data_frame
+import pandas as pd
+
+from siuba.experimental.pd_groups.translate import method_agg_op, method_el_op, method_el_op2
+#TODO: 
+#  - what if they have mandatory, non-data args?
+#  - support accessor methods like _.x.str.upper()
+#  - support .expanding and .rolling
+
+
+data_dt = data_frame(
+    g = ['a', 'a', 'b', 'b'],
+    x = pd.to_datetime(["2019-01-01 01:01:01", "2020-04-08 02:02:02", "2021-07-15 03:03:03", "2022-10-22 04:04:04"])
+    )
+
+data_str = data_frame(
+    g = ['a', 'a', 'b', 'b'],
+    x = ['abc', 'cde', 'fg', 'h']
+    )
+
+data_default = data_frame(
+    g = ['a', 'a', 'b', 'b'],
+    x = [10, 11, 12, 13],
+    y = [1,2,3,4]
+    )
+
+data = {
+    'dt': data_dt,
+    'str': data_str,
+    None: data_default
+}
+
+
+# Test translator =============================================================
+
+from pandas.testing import assert_frame_equal, assert_series_equal
+from siuba.experimental.pd_groups.groupby import GroupByAgg, SeriesGroupBy
+
+f_min = method_agg_op('min', is_property = False, accessor = None)
+f_add = method_el_op2('add', is_property = False, accessor = None)
+f_abs = method_el_op('abs', is_property = False, accessor = None)
+
+# GroupByAgg is liskov substitutable, so check that our functions operate
+# like similarly substitutable subtypes. This means that...
+# * input type is the same or more general, and
+# * output type is the same or more specific
+
+@pytest.mark.parametrize('f_op, f_dst, cls_result', [
+        # aggregation 1-arity
+        # f(SeriesGroupBy) -> GroupByAgg <= f(GroupByAgg) -> GroupByAgg 
+        (lambda g: f_min(g.x),        lambda g: g.x.min(), GroupByAgg),
+        (lambda g: f_min(f_min(g.x)), lambda g: g.x.min(), GroupByAgg),
+        # elementwise 1-arity
+        # f(GroupByAgg) -> GroupByAgg <= f(SeriesGroupBy) -> SeriesGroupBy 
+        (lambda g: f_abs(f_min(g.x)), lambda g: g.x.min().abs(), GroupByAgg),
+        (lambda g: f_abs(g.x),        lambda g: g.obj.x.abs(), SeriesGroupBy),
+        # elementwise 2-arity
+        # f(GroupByAgg, GroupByAgg) -> GroupByAgg <= f(GroupByAgg, SeriesGroupBy) -> SeriesGroupBy
+        (lambda g: f_add(f_min(g.x), f_min(g.y)), lambda g: g.x.min() + g.y.min(), GroupByAgg),
+        (lambda g: f_add(g.x, f_min(g.y)),        lambda g: g.obj.x + g.y.transform('min'), SeriesGroupBy),
+        (lambda g: f_add(g.x, g.y),               lambda g: g.obj.x + g.obj.y, SeriesGroupBy),
+        ])
+def test_grouped_translator_methods(f_op, f_dst, cls_result):
+    g = data_default.groupby('g')
+    res = f_op(g)
+
+    # needs to be exact, since GroupByAgg is subclass of SeriesGroupBy
+    assert type(res) is cls_result
+
+    dst = f_dst(g)
+    assert_series_equal(res.obj, dst, check_names = False)
+
+
+@pytest.mark.parametrize('f_op, f_dst', [
+        (lambda g: f_add(f_min(g.x), f_min(g.y)), lambda g: g.x.transform('min') + g.y.transform('min')),
+        (lambda g: f_min(g.x),        lambda g: g.x.transform('min')),
+        (lambda g: f_min(f_min(g.x)), lambda g: g.x.transform('min')),
+        (lambda g: f_abs(f_min(g.x)), lambda g: g.x.transform('min').abs()),
+        ])
+def test_agg_groupby_broadcasted_equal_to_transform(f_op, f_dst):
+    g = data_default.groupby('g')
+    res = f_op(g)
+
+    # needs to be exact, since GroupByAgg is subclass of SeriesGroupBy
+    assert type(res) is GroupByAgg
+
+    dst = f_dst(g)
+    broadcasted = res._broadcast_agg_result()
+    assert_series_equal(broadcasted, dst, check_names = False)
+
+

--- a/siuba/experimental/pd_groups/translate.py
+++ b/siuba/experimental/pd_groups/translate.py
@@ -1,8 +1,5 @@
 from .groupby import DataFrameGroupBy, GroupByAgg, SeriesGroupBy, broadcast_group_elements, _regroup
-from siuba.siu import CallTreeLocal, strip_symbolic, Call
-from siuba.dply.verbs import singledispatch2
 import pandas as pd
-import operator as op
 
 
 def is_literal(el):

--- a/siuba/experimental/pd_groups/translate.py
+++ b/siuba/experimental/pd_groups/translate.py
@@ -1,0 +1,79 @@
+from .groupby import DataFrameGroupBy, GroupByAgg, SeriesGroupBy, broadcast_group_elements, _regroup
+from siuba.siu import CallTreeLocal, strip_symbolic, Call
+from siuba.dply.verbs import singledispatch2
+import pandas as pd
+import operator as op
+
+
+def is_literal(el):
+    # TODO: pandas has this function--should use that
+    return isinstance(el, (int, float, str))
+
+def not_implemented(name, is_property, accessor):
+    return NotImplementedError
+
+def method_agg_op(name, is_property, accessor):
+    def f(__ser, *args, **kwargs):
+        if not isinstance(__ser, SeriesGroupBy):
+            raise TypeError("All methods must operate on grouped Series objects")
+        
+        method = getattr(__ser, name)
+
+        res = method(*args, **kwargs)
+        return GroupByAgg.from_result(res, __ser)
+
+    f.__name__ = name
+    f.__qualname__ = name
+    return f
+
+def method_el_op(name, is_property, accessor):
+    def f(__ser, *args, **kwargs):
+        if not isinstance(__ser, SeriesGroupBy):
+            raise TypeError("All methods must operate on a grouped Series objects")
+        
+        if accessor:
+            method = getattr(getattr(__ser.obj, accessor), name)
+        else:
+            method = getattr(__ser.obj, name)
+
+        res = method(*args, **kwargs) if not is_property else method
+        return _regroup(res, __ser)
+
+    f.__name__ = name
+    f.__qualname__ = name
+    return f
+
+def method_el_op2(name, **kwargs):
+    def f(x, y):
+        if isinstance(x, pd.Series) or isinstance(y, pd.Series):
+            raise TypeError("No Series allowed")
+
+        elif isinstance(x, SeriesGroupBy) and isinstance(y, SeriesGroupBy):
+            left, right, groupby = broadcast_group_elements(x, y)
+        elif is_literal(x):
+            right, left, groupby = x, y.obj, y
+        elif is_literal(y):
+            left, right, groupby = x.obj, y, x
+        else:
+            raise TypeError("All methods must operate on a grouped Series objects")
+        
+        op_function = getattr(left, name)
+
+        res = op_function(right)
+        return _regroup(res, groupby)
+
+    f.__name__ = name
+    f.__qualname__ = name
+    return f
+
+GROUP_METHODS = { 
+        ("Elwise", 1): method_el_op,
+        ("Elwise", 2): method_el_op2,
+        ("Agg", 1): method_agg_op,
+        ("Window", 1): not_implemented,
+        ("Window", 2): not_implemented,
+        ("Singleton", 1): not_implemented
+        }
+
+
+

--- a/siuba/siu.py
+++ b/siuba/siu.py
@@ -427,13 +427,20 @@ class CallTreeLocal(CallListener):
     def __init__(
             self,
             local,
-            rm_attr = None,
             call_sub_attr = None,
             chain_sub_attr = False,
             replace_calls = True
             ):
+        """
+        Arguments:
+            local: a dictionary mapping func_name: func, used to replace call expressions.
+            call_sub_attr: a set of attributes signaling any subattributes are property
+                           methods. Eg. {'dt'} to signify in _.dt.year, year is a property call.
+            chain_sub_attr: whether to included the attributes in the above argument, when looking up
+                           up a replacement for the property call. E.g. does local have a 'dt.year' entry.
+            replace_calls: whether all calls, including custom call objects should be replaced.
+        """
         self.local = local
-        self.rm_attr = set(rm_attr or [])
         self.call_sub_attr = set(call_sub_attr or [])
         self.chain_sub_attr = chain_sub_attr
         self.replace_calls = replace_calls

--- a/siuba/spec/series.py
+++ b/siuba/spec/series.py
@@ -1,0 +1,523 @@
+from siuba.siu import Symbolic, strip_symbolic
+# TODO: dot, corr, cov
+
+_ = Symbolic()
+
+class Result:
+    def to_dict(self):
+        return {'type': self.__class__.__name__}
+
+class Elwise(Result): pass
+class Agg(Result): pass 
+class Window(Result): pass
+class Singleton(Result): pass
+class WontImplement(Result): pass
+
+
+CATEGORIES_TIME = {
+        'time_series', 'datetime_properties', 'datetime_methods', 'period_properties',
+        'timedelta_properties', 'timedelta_methods'
+        }
+
+CATEGORIES_STRING = {
+        'string_methods'
+        }
+
+
+funcs = {
+    ## ------------------------------------------------------------------------
+    # Attributes 
+    ## ------------------------------------------------------------------------
+    '_special_methods': {
+        '__invert__': _.__invert__()         >> Elwise(),
+        '__and__': _.__and__(_)              >> Elwise(),
+        '__or__': _.__or__(_)                >> Elwise(),
+        '__xor__': _.__xor__(_)              >> Elwise(),
+        '__neg__': _.__neg__()               >> Elwise(),
+        '__pos__': _.__pos__()               >> Elwise(),
+        '__rand__': _.__rand__(_)            >> Elwise(),
+        '__ror__': _.__ror__(_)              >> Elwise(),
+        '__rxor__': _.__rxor__(_)            >> Elwise(),
+        # copied from binary section below
+        '__add__': _.add(_)               >> Elwise(),
+        '__sub__': _.sub(_)               >> Elwise(),
+        '__truediv__': _.truediv(_)       >> Elwise(),
+        '__floordiv__': _.floordiv(_)     >> Elwise(),
+        '__mul__': _.mul(_)               >> Elwise(),
+        '__mod__': _.mod(_)               >> Elwise(),
+        '__pow__': _.pow(_)               >> Elwise(),
+        '__lt__': _.lt(_)                 >> Elwise(),
+        '__gt__': _.gt(_)                 >> Elwise(),
+        '__le__': _.le(_)                 >> Elwise(),
+        '__ge__': _.ge(_)                 >> Elwise(), 
+        '__ne__': _.ne(_)                 >> Elwise(), 
+        '__eq__': _.eq(_)                 >> Elwise(), 
+        '__div__': _.div(_)               >> Elwise(), 
+        '__round__': _.round(2)           >> Elwise(), 
+        '__radd__': _.radd(_)             >> Elwise(), 
+        '__rsub__': _.rsub(_)             >> Elwise(), 
+        '__rmul__': _.rmul(_)             >> Elwise(), 
+        '__rdiv__': _.rdiv(_)             >> Elwise(), 
+        '__rtruediv__': _.rtruediv(_)     >> Elwise(),
+        '__rfloordiv__': _.rfloordiv(_)   >> Elwise(),
+        '__rmod__': _.rmod(_)             >> Elwise(),
+        '__rpow__': _.rpow(_)             >> Elwise(),
+        },
+    'attributes': {
+        # method
+        # index
+        # array
+        # values
+        # dtype
+        # ftype
+        # shape
+        # nbytes
+        # ndim
+        # size
+        # strides
+        # itemsize
+        # base
+        # T
+        # memory_usage
+        # hasnans
+        # flags
+        # empty
+        # dtypes
+        # ftypes
+        # data
+        # is_copy
+        # name
+        # put
+        },
+    ## ------------------------------------------------------------------------
+    # Conversion 
+    ## ------------------------------------------------------------------------
+    'conversion': {
+        #'astype': _.astype('str')       >> Elwise(),
+        # infer_objects
+        'copy': _.copy()              >> Elwise(),
+        # bool
+        # to_numpy
+        # to_period
+        # to_timestamp
+        # to_list
+        # get_values
+        # __array__
+        },
+    ## ------------------------------------------------------------------------
+    # Indexing, iteration 
+    ## ------------------------------------------------------------------------
+    'indexing': {
+        # get
+        # at
+        # iat
+        # loc
+        # iloc
+        # __iter__
+        # items
+        # iteritems
+        # keys
+        # pop
+        # item
+        # xs
+        },
+    ## ------------------------------------------------------------------------
+    # Binary operator functions 
+    ## ------------------------------------------------------------------------
+    'binary': {
+        'add': _.add(_)               >> Elwise(),
+        'sub': _.sub(_)               >> Elwise(),
+        'truediv': _.truediv(_)       >> Elwise(),
+        'floordiv': _.floordiv(_)     >> Elwise(),
+        'mul': _.mul(_)               >> Elwise(),
+        'mod': _.mod(_)               >> Elwise(),
+        'pow': _.pow(_)               >> Elwise(),
+        'lt': _.lt(_)                 >> Elwise(),
+        'gt': _.gt(_)                 >> Elwise(),
+        'le': _.le(_)                 >> Elwise(),
+        'ge': _.ge(_)                 >> Elwise(), 
+        'ne': _.ne(_)                 >> Elwise(), 
+        'eq': _.eq(_)                 >> Elwise(), 
+        'div': _.div(_)               >> Elwise(), 
+        'round': _.round(2)           >> Elwise(), 
+        'radd': _.radd(_)             >> Elwise(), 
+        'rsub': _.rsub(_)             >> Elwise(), 
+        'rmul': _.rmul(_)             >> Elwise(), 
+        'rdiv': _.rdiv(_)             >> Elwise(), 
+        'rtruediv': _.rtruediv(_)     >> Elwise(),
+        'rfloordiv': _.rfloordiv(_)   >> Elwise(),
+        'rmod': _.rmod(_)             >> Elwise(),
+        'rpow': _.rpow(_)             >> Elwise(),
+        # combine
+        # combine_first
+        #'product': _.product()        >> Agg(),   # TODO: doesn't exist on GroupedDataFrame
+        #'dot': _.dot(_)               >> Agg(),
+        },
+    ## ------------------------------------------------------------------------
+    # Function application, groupby & window 
+    ## ------------------------------------------------------------------------
+    'function_application': {
+        # apply
+        # agg
+        # aggregate
+        # transform
+        # map
+        # groupby
+        # rolling
+        # expanding
+        # ewm
+        # pipe
+        },
+    ## ------------------------------------------------------------------------
+    ## Computations / descriptive stats
+    ## ------------------------------------------------------------------------
+    'computations': {
+        'abs': _.abs()                >> Elwise(),
+        'all': _.all()                >> Agg(),
+        'any': _.any()                >> Agg(),
+        'autocorr': _.autocorr()      >> Window(),
+        'between': _.between(2, 5)    >> Elwise(),
+        'clip': _.clip(2, 5)          >> Elwise(),
+        # clip_lower                                # TODO: deprecated
+        # clip_upper                                # TODO: deprecated
+        #'corr': _.corr(_)             >> Agg(),
+        'count': _.count()            >> Agg(),
+        #'cov': _.cov(_)               >> Agg(),
+        'cummax': _.cummax()          >> Window(),
+        'cummin': _.cummin()          >> Window(),
+        'cumprod': _.cumprod()        >> Window(),
+        'cumsum': _.cumsum()          >> Window(),
+        # describe
+        'diff': _.diff()              >> Window(),
+        # factorize
+        # 'kurt': _.kurt()              >> Agg(),  # TODO: doesn't exist on GDF
+        'mad': _.mad()                >> Agg(),
+        'max': _.max()                >> Agg(),
+        'mean': _.mean()              >> Agg(),
+        'median': _.median()          >> Agg(),
+        'min': _.min()                >> Agg(),
+        #'mode': _.mode()              >> Agg(),   # TODO: doesn't exist on GDF, can return > 1 result
+        #'nlargest': _.nlargest()      >> Window(),
+        #'nsmallest': _.nsmallest()    >> Window(),
+        'pct_change': _.pct_change()  >> Window(),
+        'prod': _.prod()              >> Agg(),
+        'quantile': _.quantile()      >> Agg(),
+        'rank': _.rank()              >> Window(),
+        'sem': _.sem()                >> Agg(),
+        'skew': _.skew()              >> Agg(),
+        'std': _.std()                >> Agg(),
+        'sum': _.sum()                >> Agg(),
+        'var': _.var()                >> Agg(),
+        #'kurtosis': _.kurtosis()      >> Agg(),  # TODO: doesn't exist on GDF
+        # unique
+        'nunique': _.nunique()        >> Agg(),
+        #'is_unique': _.is_unique      >> Agg(),  # TODO: all is_... properties not on GDF
+        #'is_monotonic': _.is_monotonic >> Agg(),
+        #'is_monotonic_increasing': _.is_monotonic_increasing >> Agg(),
+        #'is_monotonic_decreasing': _.is_monotonic_decreasing >> Agg(),
+        # value_counts
+        # compound
+        },
+    ## ------------------------------------------------------------------------
+    # Reindexing / selection / label manipulation 
+    ## ------------------------------------------------------------------------
+    'reindexing': {
+        # align
+        # drop
+        # droplevel
+        # drop_duplicates
+        # duplicated
+        # equals
+        #'first': _.first()            >> Window(),
+        # head
+        # idxmax
+        # idxmin
+        'isin': _.isin(tuple([1,2]))  >> Elwise(),
+        #'last': _.last()              >> Window(),
+        # reindex
+        # reindex_like
+        # rename
+        # rename_axis
+        # reset_index
+        # sample
+        # set_axis
+        # take
+        # tail
+        # truncate
+        # where
+        # mask
+        # add_prefix
+        # add_suffix
+        # filter
+        },
+    ## ------------------------------------------------------------------------
+    # Missing data handling 
+    ## ------------------------------------------------------------------------
+    'missing_data': {
+        'isna':  _.isna()             >> Elwise(),
+        'notna': _.notna()            >> Elwise(),
+        # dropna
+        'fillna': _.fillna(1)         >> Elwise(),
+        # interpolate
+        },
+    ## ------------------------------------------------------------------------
+    # Reshaping, sorting 
+    ## ------------------------------------------------------------------------
+    'reshaping': {
+        # argsort
+        # argmin
+        # argmax
+        # reorder_levels
+        # sort_values
+        # sort_index
+        # swaplevel
+        # unstack
+        # explode
+        # searchsorted
+        # ravel
+        # repeat
+        # squeeze
+        # view
+        },
+    ## ------------------------------------------------------------------------
+    # Combining / joining / merging 
+    ## ------------------------------------------------------------------------
+    'combining': {
+        # append
+        # replace
+        # update
+        },
+    ## ------------------------------------------------------------------------
+    # Time series-related 
+    ## ------------------------------------------------------------------------
+    'time_series': {
+        # asfreq
+        # asof
+        # shift
+        # first_valid_index
+        # last_valid_index
+        # resample
+        # tz_convert
+        # tz_localize
+        # at_time
+        # between_time
+        # tshift
+        # slice_shift
+        },
+    ## ------------------------------------------------------------------------
+    # Datetime properties 
+    ## ------------------------------------------------------------------------
+    'datetime_properties': {
+        'dt.date': _.dt.date                             >> Elwise(),
+        'dt.time': _.dt.time                             >> Elwise(),
+        'dt.timetz': _.dt.timetz                         >> Elwise(),
+        'dt.year': _.dt.year                             >> Elwise(),
+        'dt.month': _.dt.month                           >> Elwise(),
+        'dt.day': _.dt.day                               >> Elwise(),
+        'dt.hour': _.dt.hour                             >> Elwise(),
+        'dt.minute': _.dt.minute                         >> Elwise(),
+        'dt.second': _.dt.second                         >> Elwise(),
+        'dt.microsecond': _.dt.microsecond               >> Elwise(),
+        'dt.nanosecond': _.dt.nanosecond                 >> Elwise(),
+        'dt.week': _.dt.week                             >> Elwise(),
+        'dt.weekofyear': _.dt.weekofyear                 >> Elwise(),
+        'dt.dayofweek': _.dt.dayofweek                   >> Elwise(),
+        'dt.weekday': _.dt.weekday                       >> Elwise(),
+        'dt.dayofyear': _.dt.dayofyear                   >> Elwise(),
+        'dt.quarter': _.dt.quarter                       >> Elwise(),
+        'dt.is_month_start': _.dt.is_month_start         >> Elwise(),
+        'dt.is_month_end': _.dt.is_month_end             >> Elwise(),
+        'dt.is_quarter_start': _.dt.is_quarter_start     >> Elwise(),
+        'dt.is_quarter_end': _.dt.is_quarter_end         >> Elwise(),
+        'dt.is_year_start': _.dt.is_year_start           >> Elwise(),
+        'dt.is_year_end': _.dt.is_year_end               >> Elwise(),
+        'dt.is_leap_year': _.dt.is_leap_year             >> Elwise(),
+        'dt.daysinmonth': _.dt.daysinmonth               >> Elwise(),
+        'dt.days_in_month': _.dt.days_in_month           >> Elwise(),
+        'dt.tz': _.dt.tz                                 >> Singleton(),
+        'dt.freq': _.dt.freq                             >> Singleton(),
+        },
+    ## ------------------------------------------------------------------------
+    # Datetime methods 
+    ## ------------------------------------------------------------------------
+    'datetime_methods': {
+        'dt.to_period': _.dt.to_period('D')             >> Elwise(),
+        # dt.to_pydatetime                                              # TODO: datetime objects converted back to numpy?
+        'dt.tz_localize': _.dt.tz_localize('UTC')       >> Elwise(),
+        # dt.tz_convert                                                 # TODO: need custom test
+        'dt.normalize': _.dt.normalize()                >> Elwise(),
+        'dt.strftime': _.dt.strftime('%d')              >> Elwise(),
+        'dt.round': _.dt.round('D')                     >> Elwise(),
+        'dt.floor': _.dt.floor('D')                     >> Elwise(),
+        'dt.ceil': _.dt.ceil('D')                       >> Elwise(),
+        'dt.month_name': _.dt.month_name()              >> Elwise(),
+        'dt.day_name': _.dt.day_name()                  >> Elwise(),
+        },
+    ## ------------------------------------------------------------------------
+    # Period properties 
+    ## ------------------------------------------------------------------------
+    'period_properties': {
+        # dt.qyear
+        # dt.start_time
+        # dt.end_time
+        },
+    ## ------------------------------------------------------------------------
+    # Timedelta properties 
+    ## ------------------------------------------------------------------------
+    'timedelta_properties': {
+        # dt.days
+        # dt.seconds
+        # dt.microseconds
+        # dt.nanoseconds
+        # dt.components
+        },
+    ## ------------------------------------------------------------------------
+    # Timedelta methods 
+    ## ------------------------------------------------------------------------
+    'timedelta_methods': {
+        # dt.to_pytimedelta
+        # dt.total_seconds
+        },
+    ## ------------------------------------------------------------------------
+    ## String methods
+    ## ------------------------------------------------------------------------
+    'string_methods': {
+        'str.capitalize': _.str.capitalize()              >> Elwise(),
+        #'str.casefold': _.str.casefold()                  >> Elwise(),   #TODO: introduced in v0.25.1
+        # str.cat                                                         #TODO: can be Agg OR Elwise, others arg
+        'str.center': _.str.center(3)                     >> Elwise(),
+        'str.contains': _.str.contains('a')               >> Elwise(),
+        'str.count': _.str.count('a')                     >> Elwise(),
+        # str.decode                                                      # TODO custom testing
+        'str.encode': _.str.encode('utf-8')               >> Elwise(),
+        'str.endswith': _.str.endswith('a|b')             >> Elwise(),
+        #'str.extract': _.str.extract('(a)(b)')                           # TODO: returns DataFrame
+        # str.extractall
+        'str.find': _.str.find('a|c')                     >> Elwise(),
+        'str.findall': _.str.findall('a|c')               >> Elwise(),
+        # str.get                                                         # TODO: custom test
+        # str.index                                                       # TODO: custom test
+        # str.join                                                        # TODO: custom test
+        'str.len': _.str.len()                            >> Elwise(),
+        'str.ljust': _.str.ljust(5)                       >> Elwise(),
+        'str.lower': _.str.lower()                        >> Elwise(),
+        'str.lstrip': _.str.lstrip()                      >> Elwise(),
+        'str.match': _.str.match('a|c')                   >> Elwise(),
+        # str.normalize
+        'str.pad': _.str.pad(5)                           >> Elwise(),
+        # str.partition
+        # str.repeat
+        'str.replace': _.str.replace('a|b', 'c')          >> Elwise(),
+        'str.rfind': _.str.rfind('a')                     >> Elwise(),
+        # str.rindex
+        'str.rjust': _.str.rjust(5)                       >> Elwise(),
+        # str.rpartition
+        'str.rstrip': _.str.rstrip()                      >> Elwise(),
+        'str.slice': _.str.slice(step = 2)                >> Elwise(),
+        'str.slice_replace': _.str.slice_replace(2, repl = 'x')   >> Elwise(),
+        'str.split': _.str.split('a|b')                   >> Elwise(),
+        'str.rsplit': _.str.rsplit('a|b', n = 1)          >> Elwise(),
+        'str.startswith': _.str.startswith('a|b')         >> Elwise(),
+        'str.strip': _.str.strip()                        >> Elwise(),
+        'str.swapcase': _.str.swapcase()                  >> Elwise(),
+        'str.title': _.str.title()                        >> Elwise(),
+        # str.translate
+        'str.upper': _.str.upper()                        >> Elwise(),
+        'str.wrap': _.str.wrap(2)                         >> Elwise(),
+        # str.zfill
+        'str.isalnum': _.str.isalnum()                    >> Elwise(),
+        'str.isalpha': _.str.isalpha()                    >> Elwise(),
+        'str.isdigit': _.str.isdigit()                    >> Elwise(),
+        'str.isspace': _.str.isspace()                    >> Elwise(),
+        'str.islower': _.str.islower()                    >> Elwise(),
+        'str.isupper': _.str.isupper()                    >> Elwise(),
+        'str.istitle': _.str.istitle()                    >> Elwise(),
+        'str.isnumeric': _.str.isnumeric()                >> Elwise(),
+        'str.isdecimal': _.str.isdecimal()                >> Elwise(),
+        # str.get_dummies
+        },
+    'categories': {
+        # cat.categories
+        # cat.ordered
+        # cat.codes
+        # cat.rename_categories
+        # cat.reorder_categories
+        # cat.add_categories
+        # cat.remove_categories
+        # cat.remove_unused_categories
+        # cat.set_categories
+        # cat.as_ordered
+        # cat.as_unordered
+        },
+    'sparse': {
+        # sparse
+        # sparse.npoints
+        # sparse.density
+        # sparse.fill_value
+        # sparse.sp_values
+        # sparse.from_coo
+        # sparse.to_coo
+        },
+    ## ------------------------------------------------------------------------
+    # Plotting 
+    ## ------------------------------------------------------------------------
+    # plot
+    # plot.area
+    # plot.bar
+    # plot.barh
+    # plot.box
+    # plot.density
+    # plot.hist
+    # plot.kde
+    # plot.line
+    # plot.pie
+    # hist
+    ## ------------------------------------------------------------------------
+    # Serialization / IO / conversion 
+    ## ------------------------------------------------------------------------
+    # to_pickle
+    # to_csv
+    # to_dict
+    # to_excel
+    # to_frame
+    # to_xarray
+    # to_hdf
+    # to_sql
+    # to_msgpack
+    # to_json
+    # to_dense
+    # to_string
+    # to_clipboard
+    # to_latex
+    }
+
+from siuba.spec.utils import get_type_info
+import itertools
+
+funcs_stripped = { 
+        section_name: { k: strip_symbolic(v) for k,v in section.items()}
+          for section_name, section in funcs.items()
+          } 
+
+
+all_funcs = dict(itertools.chain(*[x.items() for x in funcs_stripped.values()]))
+
+
+# Get spec =====
+nested_spec = {}
+for category, call_dict in funcs_stripped.items():
+    nested_spec[category] = d = {}
+    for name, call in call_dict.items():
+        d[name] = get_type_info(call)
+
+
+spec = dict(itertools.chain(*iter(d.items() for d in nested_spec.values())))
+
+if __name__ == "__main__":
+    from siuba.spec.utils import dump_spec
+    import sys
+    from pathlib import Path
+    path_spec = Path(sys.argv[0]).parent / 'series.yml'
+    
+    with open(str(path_spec), 'w') as f:
+        dump_spec(nested_spec, f)

--- a/siuba/spec/series.py
+++ b/siuba/spec/series.py
@@ -4,8 +4,11 @@ from siuba.siu import Symbolic, strip_symbolic
 _ = Symbolic()
 
 class Result:
+    def __init__(self, **kwargs):
+        self.options = kwargs
+
     def to_dict(self):
-        return {'type': self.__class__.__name__}
+        return {'type': self.__class__.__name__, **self.options}
 
 class Elwise(Result): pass
 class Agg(Result): pass 
@@ -29,39 +32,39 @@ funcs = {
     # Attributes 
     ## ------------------------------------------------------------------------
     '_special_methods': {
-        '__invert__': _.__invert__()         >> Elwise(),
-        '__and__': _.__and__(_)              >> Elwise(),
-        '__or__': _.__or__(_)                >> Elwise(),
-        '__xor__': _.__xor__(_)              >> Elwise(),
+        '__invert__': _.__invert__()         >> Elwise(op = 'bool'),
+        '__and__': _.__and__(_)              >> Elwise(op = 'bool'),
+        '__or__': _.__or__(_)                >> Elwise(op = 'bool'),
+        '__xor__': _.__xor__(_)              >> Elwise(op = 'bool'),
         '__neg__': _.__neg__()               >> Elwise(),
         '__pos__': _.__pos__()               >> Elwise(),
-        '__rand__': _.__rand__(_)            >> Elwise(),
-        '__ror__': _.__ror__(_)              >> Elwise(),
-        '__rxor__': _.__rxor__(_)            >> Elwise(),
+        '__rand__': _.__rand__(_)            >> Elwise(op = 'bool'),
+        '__ror__': _.__ror__(_)              >> Elwise(op = 'bool'),
+        '__rxor__': _.__rxor__(_)            >> Elwise(op = 'bool'),
         # copied from binary section below
-        '__add__': _.add(_)               >> Elwise(),
-        '__sub__': _.sub(_)               >> Elwise(),
-        '__truediv__': _.truediv(_)       >> Elwise(),
-        '__floordiv__': _.floordiv(_)     >> Elwise(),
-        '__mul__': _.mul(_)               >> Elwise(),
-        '__mod__': _.mod(_)               >> Elwise(),
-        '__pow__': _.pow(_)               >> Elwise(),
-        '__lt__': _.lt(_)                 >> Elwise(),
-        '__gt__': _.gt(_)                 >> Elwise(),
-        '__le__': _.le(_)                 >> Elwise(),
-        '__ge__': _.ge(_)                 >> Elwise(), 
-        '__ne__': _.ne(_)                 >> Elwise(), 
-        '__eq__': _.eq(_)                 >> Elwise(), 
-        '__div__': _.div(_)               >> Elwise(), 
-        '__round__': _.round(2)           >> Elwise(), 
-        '__radd__': _.radd(_)             >> Elwise(), 
-        '__rsub__': _.rsub(_)             >> Elwise(), 
-        '__rmul__': _.rmul(_)             >> Elwise(), 
-        '__rdiv__': _.rdiv(_)             >> Elwise(), 
-        '__rtruediv__': _.rtruediv(_)     >> Elwise(),
-        '__rfloordiv__': _.rfloordiv(_)   >> Elwise(),
-        '__rmod__': _.rmod(_)             >> Elwise(),
-        '__rpow__': _.rpow(_)             >> Elwise(),
+        '__add__': _.__add__(_)               >> Elwise(),
+        '__sub__': _.__sub__(_)               >> Elwise(),
+        '__truediv__': _.__truediv__(_)       >> Elwise(),
+        '__floordiv__': _.__floordiv__(_)     >> Elwise(),
+        '__mul__': _.__mul__(_)               >> Elwise(),
+        '__mod__': _.__mod__(_)               >> Elwise(),
+        '__pow__': _.__pow__(_)               >> Elwise(),
+        '__lt__': _.__lt__(_)                 >> Elwise(),
+        '__gt__': _.__gt__(_)                 >> Elwise(),
+        '__le__': _.__le__(_)                 >> Elwise(),
+        '__ge__': _.__ge__(_)                 >> Elwise(), 
+        '__ne__': _.__ne__(_)                 >> Elwise(), 
+        '__eq__': _.__eq__(_)                 >> Elwise(), 
+        '__div__': _.__div__(_)               >> Elwise(), 
+        '__round__': _.__round__(2)           >> Elwise(), 
+        '__radd__': _.__radd__(_)             >> Elwise(), 
+        '__rsub__': _.__rsub__(_)             >> Elwise(), 
+        '__rmul__': _.__rmul__(_)             >> Elwise(), 
+        '__rdiv__': _.__rdiv__(_)             >> Elwise(), 
+        '__rtruediv__': _.__rtruediv__(_)     >> Elwise(),
+        '__rfloordiv__': _.__rfloordiv__(_)   >> Elwise(),
+        '__rmod__': _.__rmod__(_)             >> Elwise(),
+        '__rpow__': _.__rpow__(_)             >> Elwise(),
         },
     'attributes': {
         # method

--- a/siuba/spec/utils.py
+++ b/siuba/spec/utils.py
@@ -1,0 +1,62 @@
+from siuba.siu import _, MetaArg, strip_symbolic
+import itertools
+
+def get_type_info(call):
+    if call.func != "__rshift__":
+        raise ValueError("Expected first expressions was >>")
+        
+    out = {}
+    expr, result = call.args
+    
+    accessors = ['str', 'dt', 'cat']
+    
+    accessor = [ameth for ameth in accessors if ameth in expr.op_vars()] + [None]
+            
+    return dict(
+        expr_series = expr,
+        expr_frame = replace_meta_args(expr, _.x, _.y, _.z),
+        accessor = accessor[0],
+        result = result.to_dict(),
+        is_property = expr.func == "__getattr__",
+        data_arity = count_call_type(expr, MetaArg)
+    )
+
+def count_call_type(call, cls):
+    """Counts the number of MetaArgs"""
+    meta_count = 0
+    def incr_meta_count(node):
+        nonlocal meta_count
+        if isinstance(node, cls): 
+            meta_count += 1
+        node.map_subcalls(incr_meta_count)
+    
+    incr_meta_count(call)
+    
+    return meta_count
+
+def replace_meta_args(call, *args):
+    replacements = map(strip_symbolic, args)
+    
+    def replace_next(node):
+        # swap in first replacement for meta arg (when possible)
+        if isinstance(node, MetaArg):
+            return next(replacements)
+        
+        # otherwise, recurse into node
+        args, kwargs = node.map_subcalls(replace_next)
+
+        # return a copy of node
+        return node.__class__(node.func, *args, **kwargs)
+
+    return replace_next(call)
+
+def dump_spec(spec, stream = None):
+    import yaml
+    # TODO: do this without mutating SafeDumper...
+    yaml.SafeDumper.yaml_representers[None] = lambda self, data: \
+        yaml.representer.SafeRepresenter.represent_str(
+            self,
+            str(data),
+        )
+
+    return yaml.safe_dump(spec, stream)

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -225,7 +225,6 @@ class LazyTbl:
         funcs = {**f_dict1, **f_dict2}
         call_shaper = CallTreeLocal(
                 funcs,
-                rm_attr = self.rm_attr,
                 call_sub_attr = self.call_sub_attr
                 )
 

--- a/siuba/tests/conftest.py
+++ b/siuba/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from .helpers import assert_equal_query, Backend, SqlBackend, data_frame
+from .helpers import assert_equal_query, PandasBackend, SqlBackend, data_frame
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -9,7 +9,7 @@ def pytest_addoption(parser):
 params_backend = [
     pytest.param(lambda: SqlBackend("postgresql"), id = "postgresql", marks=pytest.mark.postgresql),
     pytest.param(lambda: SqlBackend("sqlite"), id = "sqlite", marks=pytest.mark.sqlite),
-    pytest.param(lambda: Backend("pandas"), id = "pandas", marks=pytest.mark.pandas)
+    pytest.param(lambda: PandasBackend("pandas"), id = "pandas", marks=pytest.mark.pandas)
     ]
 
 @pytest.fixture(params = params_backend, scope = "session")

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -103,7 +103,13 @@ def assert_frame_sort_equal(a, b):
 
 def assert_equal_query(tbl, lazy_query, target):
     out = collect(lazy_query(tbl))
-    assert_frame_sort_equal(out, target)
+
+    if isinstance(tbl, pd.DataFrame):
+        df_a = ungroup(out).reset_index(drop = True)
+        df_b = ungroup(target).reset_index(drop = True)
+        assert_frame_equal(df_a, df_b)
+    else:
+        assert_frame_sort_equal(out, target)
 
 
 PREFIX_TO_TYPE = {

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -47,6 +47,8 @@ class Backend:
     def __repr__(self):
         return "{0}({1})".format(self.__class__.__name__, repr(self.name))
 
+class PandasBackend(Backend):
+    pass
 
 class SqlBackend(Backend):
     table_name_indx = 0
@@ -72,12 +74,30 @@ class SqlBackend(Backend):
         return copy_to_sql(df, self.unique_table_name(), self.engine)
 
 
+def robust_multiple_sort(df, by):
+    """Sort a DataFrame on multiple columns, slower but more reliable than df.sort_values
+
+    Note: pandas errors when you sort by multiple columns, and one has unhashable objects.
+          however, it can "sort" a single column with unhashable objects.
+
+          e.g. df.sort_values(by = ['a', 'b']) may cause an error
+
+    This implementation chains sort_values on single columns. In this case,
+    pandas sorts a list based on its first entry ¯\_(ツ)_/¯.
+    """
+
+    from functools import reduce
+
+    out = reduce(lambda data, col: data.sort_values(col), by, df)
+
+    return out.reset_index(drop = True)
+
 def assert_frame_sort_equal(a, b):
     """Tests that DataFrames are equal, even if rows are in different order"""
     df_a = ungroup(a)
     df_b = ungroup(b)
-    sorted_a = df_a.sort_values(by = df_a.columns.tolist()).reset_index(drop = True)
-    sorted_b = df_b.sort_values(by = df_b.columns.tolist()).reset_index(drop = True)
+    sorted_a = robust_multiple_sort(df_a, list(df_b.columns)).reset_index(drop = True)
+    sorted_b = robust_multiple_sort(df_b, list(df_b.columns)).reset_index(drop = True)
 
     assert_frame_equal(sorted_a, sorted_b)
 
@@ -136,6 +156,21 @@ def backend_sql(msg):
         @wraps(f)
         def wrapper(backend, *args, **kwargs):
             if not isinstance(backend, SqlBackend):
+                pytest.skip(msg)
+            else:
+                return f(backend, *args, **kwargs)
+        return wrapper
+    return outer
+
+def backend_pandas(msg):
+    # allow decorating without an extra call
+    if callable(msg):
+        return backend_pandas(None)(msg)
+
+    def outer(f):
+        @wraps(f)
+        def wrapper(backend, *args, **kwargs):
+            if not isinstance(backend, PandasBackend):
                 pytest.skip(msg)
             else:
                 return f(backend, *args, **kwargs)

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -1,6 +1,6 @@
 from siuba.siu import Symbolic, strip_symbolic
 from siuba.spec.series import spec
-from .helpers import data_frame, assert_equal_query, backend_pandas
+from .helpers import data_frame, assert_equal_query, backend_pandas, SqlBackend
 import pytest
 # TODO: dot, corr, cov
 
@@ -111,6 +111,9 @@ def test_frame_expr(entry):
 @backend_pandas
 #@pytest.mark.skip_backend('sqlite')
 def test_frame_mutate(backend, entry):
+    if isinstance(backend, SqlBackend) and entry['result'].get('op') == 'bool':
+        pytest.xfail()
+
     crnt_data = data[entry['accessor']]
     df = backend.load_df(crnt_data)
 

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -1,0 +1,182 @@
+from siuba.siu import Symbolic, strip_symbolic
+from siuba.spec.series import spec
+from .helpers import data_frame, assert_equal_query, backend_pandas
+import pytest
+# TODO: dot, corr, cov
+
+from siuba import filter, mutate, summarize
+from pandas.testing import assert_frame_equal, assert_series_equal
+import numpy as np
+import pandas as pd
+import pkg_resources
+
+def filter_on_result(spec, types):
+    return [k for k,v in spec.items() if v['result']['type'] in types]
+
+SPEC_IMPLEMENTED = filter_on_result(spec, {"Agg", "Elwise"})
+SPEC_NOTIMPLEMENTED = filter_on_result(spec, {"Window", "Singleton"})
+SPEC_AGG = filter_on_result(spec, {"Agg"})
+
+_ = Symbolic()
+
+@pytest.fixture(params = tuple(SPEC_IMPLEMENTED))
+def entry(request):
+    # NOTE: the sole purpose of putting in a fixture is so pytest line output
+    #       is very easy to read. (e.g. pytest -v --tb=line)
+    key = request.param
+    yield spec[key]
+
+@pytest.fixture(params = tuple(SPEC_AGG))
+def agg_entry(request):
+    key = request.param
+    yield spec[key]
+
+@pytest.fixture(params = tuple(SPEC_NOTIMPLEMENTED))
+def notimpl_entry(request):
+    key  = request.param
+    yield spec[key]
+
+def assert_src_array_equal(src, dst):
+    if isinstance(src, np.ndarray):
+        assert np.array_equal(src, dst)
+    elif isinstance(src, pd.DataFrame):
+        assert_frame_equal(src, dst)
+    elif isinstance(src, pd.Series):
+        assert_series_equal(src, dst, check_names = False)
+    else:
+        assert src == dst
+    
+# Data ========================================================================
+data_dt = data_frame(
+    g = ['a', 'a', 'b', 'b'],
+    x = pd.to_datetime(["2019-01-01 01:01:01", "2020-04-08 02:02:02", "2021-07-15 03:03:03", "2022-10-22 04:04:04"])
+    )
+
+data_str = data_frame(
+    g = ['a', 'a', 'b', 'b'],
+    x = ['abc', 'cde', 'fg', 'h']
+    )
+
+data_default = data_frame(
+    g = ['a', 'a', 'a', 'b', 'b', 'b'],
+    x = [10, 11, 11, 13, 13, 13],
+    y = [1,2,3,4,5,6]
+    )
+
+data = {
+    'dt': data_dt,
+    'str': data_str,
+    None: data_default
+}
+
+# Tests =======================================================================
+
+# Series expr and call return same result
+
+# Series expr and Postgres return same result
+
+# Series agg and trivial group agg return same result (when cast dimless)
+
+def test_series_against_call(entry):
+    if entry['result']['type'] == "Window":
+        pytest.skip()
+
+    df = data[entry['accessor']]
+    # TODO: once reading from yaml, no need to repr
+    str_expr = str(entry['expr_series'])
+
+    call_expr = strip_symbolic(eval(str_expr, {'_': _}))
+    res = call_expr(df.x)
+
+    dst = eval(str_expr, {'_': df.x})
+    
+    assert res.__class__ is dst.__class__
+    assert_src_array_equal(res, dst)
+
+
+def test_frame_expr(entry):
+    df = data[entry['accessor']]
+    # TODO: once reading from yaml, no need to repr
+    str_expr = str(entry['expr_frame'])
+
+    call_expr = strip_symbolic(eval(str_expr, {'_': _}))
+    res = call_expr(df)
+
+    dst = eval(str_expr, {'_': df})
+    
+    assert res.__class__ is dst.__class__
+    assert_src_array_equal(res, dst)
+
+
+@backend_pandas
+#@pytest.mark.skip_backend('sqlite')
+def test_frame_mutate(backend, entry):
+    crnt_data = data[entry['accessor']]
+    df = backend.load_df(crnt_data)
+
+    # TODO: once reading from yaml, no need to repr
+    str_expr = str(entry['expr_frame'])
+    call_expr = strip_symbolic(eval(str_expr, {'_': _}))
+
+    dst_series = eval(str_expr, {'_': crnt_data})
+    dst = crnt_data.assign(result = dst_series)
+    
+    assert_equal_query(df, mutate(result = call_expr), dst)
+
+
+def test_pandas_grouped_frame_fast_not_implemented(notimpl_entry):
+    from siuba.experimental.pd_groups.dialect import fast_mutate
+    gdf = data[notimpl_entry['accessor']].groupby('g')
+
+    # TODO: once reading from yaml, no need to repr
+    str_expr = str(notimpl_entry['expr_frame'])
+    call_expr = strip_symbolic(eval(str_expr, {'_': _}))
+
+    with pytest.raises(NotImplementedError):
+        res = fast_mutate(gdf, result = call_expr)
+    
+
+def test_pandas_grouped_frame_fast_mutate(entry):
+    from siuba.experimental.pd_groups.dialect import fast_mutate, DataFrameGroupBy
+    gdf = data[entry['accessor']].groupby('g')
+
+    # TODO: once reading from yaml, no need to repr
+    str_expr = str(entry['expr_frame'])
+    call_expr = strip_symbolic(eval(str_expr, {'_': _}))
+
+    res = fast_mutate(gdf, result = call_expr)
+    dst = mutate(gdf, result = call_expr)
+
+    # fix mutate's current bad behavior of reordering rows ---
+    dst_obj_fixed = dst.obj.reset_index('g', drop = True).loc[pd.RangeIndex(len(gdf.obj))]
+
+    # TODO: apply mark to skip failing tests, rather than downcast
+    # pandas grouped aggs, when not using cython, _try_cast back to original type
+    # but since mutate uses apply, it doesn't :/. Currently only affects median func.
+    if str_expr == '_.x.median()':
+        dst_obj_fixed['result'] = gdf._try_cast(dst_obj_fixed['result'], gdf.x.obj)
+
+    assert isinstance(dst, DataFrameGroupBy)
+    assert_frame_equal(res.obj, dst_obj_fixed)
+
+
+#@pytest.mark.skip_backend('sqlite')
+@backend_pandas
+def test_frame_summarize_trivial(backend, agg_entry):
+    crnt_data = data[agg_entry['accessor']]
+    df = backend.load_df(crnt_data)
+
+    # TODO: once reading from yaml, no need to repr
+    str_expr = str(agg_entry['expr_frame'])
+
+    call_expr = strip_symbolic(eval(str_expr, {'_': _}))
+    res = summarize(df, result = call_expr)
+
+    # Perform a trivial group agg, where the entire frame is 1 group
+    dst_out = eval(str_expr, {'_': df})
+    dst_series = dst_out if isinstance(dst_out, pd.Series) else pd.Series(dst_out)
+    dst = pd.DataFrame({'result': dst_series})
+    
+    assert_frame_equal(res, dst)
+
+

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -148,7 +148,8 @@ def test_pandas_grouped_frame_fast_mutate(entry):
     dst = mutate(gdf, result = call_expr)
 
     # fix mutate's current bad behavior of reordering rows ---
-    dst_obj_fixed = dst.obj.reset_index('g', drop = True).loc[pd.RangeIndex(len(gdf.obj))]
+    # (fixed in issue #139)
+    dst_obj_fixed = dst.obj
 
     # TODO: apply mark to skip failing tests, rather than downcast
     # pandas grouped aggs, when not using cython, _try_cast back to original type

--- a/siuba/tests/test_dply_verbs.py
+++ b/siuba/tests/test_dply_verbs.py
@@ -3,7 +3,7 @@ This file is for pandas specific verb operations.
 """
 
 import pytest
-from siuba.dply.verbs import mutate, arrange, filter
+from siuba.dply.verbs import mutate, arrange, filter, ungroup
 from siuba.siu import _
 
 import pandas as pd
@@ -44,6 +44,18 @@ def test_dply_mutate(df1):
     out2 = df1.assign(stars_1k = op_stars_1k)
 
     assert_frame_equal(out1, out2)
+
+def test_dply_grouped_mutate_of_agg_order():
+    # see issue #139
+    df = pd.DataFrame({
+        'g': ['b', 'a', 'b'],
+        'x':[0, 1, 2]
+        })
+    gdf = df.groupby('g')
+    
+    out = mutate(gdf, g_min = lambda d: d.x.min())
+
+    assert_frame_equal(ungroup(out), df.assign(g_min = [0, 1, 0]))
 
 def test_dply_mutate_sym(df1):
     op_stars_1k = _.stars * 1000

--- a/siuba/tests/test_verb_summarize.py
+++ b/siuba/tests/test_verb_summarize.py
@@ -98,3 +98,11 @@ def test_summarize_unnamed_args(df):
             pd.DataFrame({'n(_)': 4})
             )
 
+
+@pytest.mark.skip("TODO: Summarize should fail when result len > 1 (#138)")
+def test_frame_mode_returns_many():
+    with pytest.raises(ValueError):
+        df = data_frame(x = [1, 2, 3])
+        res = summarize(df, result = _.x.mode())
+
+


### PR DESCRIPTION
**Features**

* Implementation of fast mutate, filter, and summarize using CallTreeLocal (#134)
* fixed current grouped pandas mutate to preserve row order (#139)
* laid down tests of all supported series methods, currently skipping SQL backends (but ready to go!)
* put up some very basic documentation (#145)
* wrote an ADR on the rational for fast groupby (#135)

Note that CallTreeLocal has new options, allowing it to look up based on chained attributes (e.g. look for an entry named "dt.year", and override custom function calls.).

I still need to finish support for user defined operations and some light siu refactoring.

**Breaking changes**

* Removed the rm_attr argument from CallTreeLocal, since converting subattrs like `dt.year` will consume `dt` anyway (can't imagine a situation where we'd want to keep it, and couldn't do that in the translator function)