### PR TITLE
fix CallTreeLocal not removing sub_attr from method calls

### DIFF
--- a/siuba/siu.py
+++ b/siuba/siu.py
@@ -511,9 +511,9 @@ class CallTreeLocal(CallListener):
         attr_chain, target = get_attr_chain(obj, max_n = 2)
         if attr_chain:
             # want _.x.method() -> method(_.x), need to transform
-            if attr_chain[0] in self.call_sub_attr and self.chain_sub_attr:
+            if attr_chain[0] in self.call_sub_attr:
                 # e.g. _.dt.round()
-                call_name = ".".join(attr_chain)
+                call_name = ".".join(attr_chain) if self.chain_sub_attr else attr_chain[-1]
                 entered_target = self.enter_if_call(target)
             else:
                 call_name = attr_chain[-1]

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -152,7 +152,7 @@ class LazyTbl:
     def __init__(
             self, source, tbl, columns = None,
             ops = None, group_by = tuple(), order_by = tuple(), funcs = None,
-            rm_attr = ('str', 'dt'), call_sub_attr = ('dt',)
+            rm_attr = ('str', 'dt'), call_sub_attr = ('dt', 'str')
             ):
         """Create a representation of a SQL table.
 

--- a/siuba/tests/test_siu.py
+++ b/siuba/tests/test_siu.py
@@ -1,4 +1,40 @@
-from siuba.siu import _, strip_symbolic
+from siuba.siu import _, strip_symbolic, CallTreeLocal, FunctionLookupError
+import pytest
 
 def test_op_vars_slice():
     assert strip_symbolic(_.a[_.b:_.c]).op_vars() == {'a', 'b', 'c'}
+
+# Call Tree Local =============================================================
+
+@pytest.fixture
+def ctl():
+    local = {'f_a': lambda self: self}
+    yield CallTreeLocal(local, call_sub_attr = ('str', 'dt'))
+
+
+def test_call_tree_local_sub_attr_method(ctl):
+    # sub attr gets stripped w/ method call
+    call = ctl.enter(strip_symbolic(_.str.f_a()))
+    assert call('x') == 'x'
+
+def test_call_tree_local_sub_attr_property(ctl):
+    # sub attr gets stripped w/ property access
+    call = ctl.enter(strip_symbolic(_.str.f_a))
+    assert call('x') == 'x'
+
+def test_call_tree_local_sub_attr_alone(ctl):
+    # attr alone is treated like a normal getattr
+    call = ctl.enter(strip_symbolic(_.str))
+    assert call.func == "__getattr__"
+    assert call.args[1] == "str"
+
+def test_call_tree_local_sub_attr_method_missing(ctl):
+    # subattr raises lookup errors (method)
+    with pytest.raises(FunctionLookupError):
+        ctl.enter(strip_symbolic(_.str.f_b()))
+
+def test_call_tree_local_sub_attr_property_missing(ctl):
+    # subattr raises lookup errors (property)
+    with pytest.raises(FunctionLookupError):
+        ctl.enter(strip_symbolic(_.str.f_b))
+


### PR DESCRIPTION
Fixes regression where SQL translations for `str` accessor methods don't remove the `str` portion. Adds tests to avoid this the future.