### PR TITLE
tests: add python 3.8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,18 @@ python:
   - "3.7-dev"  # 3.7 development branch
   - "3.8-dev"
 # command to install dependencies
-install:
-  - pip install -r requirements.txt
-  - pip install .
+jobs:
+  include:
+  - install:
+      - pip install -r requirements.txt
+      - pip install .
+  - install:
+      - pip install numpy==1.17.4 pandas==0.24.2 SQLAlchemy==1.2.19 psycopg2==2.8.4
+      - pip install pytest==4.4.2 hypothesis==4.50.2
+  - install:
+      - pip install numpy==1.17.4 pandas~=0.25.3 SQLAlchemy~=1.3.11 psycopg2~=2.8.4
+      - pip install pytest==4.4.2 hypothesis==4.50.2
+      
 # command to run tests
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 #  - "3.6"
   - "3.6-dev"  # 3.6 development branch
   - "3.7-dev"  # 3.7 development branch
+  - "3.8-dev"
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,21 @@ python:
 # command to install dependencies
 jobs:
   include:
-  - install:
-      - pip install -r requirements.txt
-      - pip install .
-  - install:
+  - name: "Minimum install_requires versions"
+    install:
+      - pip install numpy~=1.12.0 pandas~=0.24.0 SQLAlchemy~=1.1.18 psycopg2~=2.7.0
+      - pip install pytest==4.4.2 hypothesis==4.50.2
+  - name: "Late 2019 dependencies"
+    install:
       - pip install numpy==1.17.4 pandas==0.24.2 SQLAlchemy==1.2.19 psycopg2==2.8.4
       - pip install pytest==4.4.2 hypothesis==4.50.2
-  - install:
+  - name: "Newest studied dependency versions"
+    install:
       - pip install numpy==1.17.4 pandas~=0.25.3 SQLAlchemy~=1.3.11 psycopg2~=2.8.4
+      - pip install pytest==4.4.2 hypothesis==4.50.2
+  - name: "Pure setup.py install"
+    install:
+      - pip install ./
       - pip install pytest==4.4.2 hypothesis==4.50.2
       
 # command to run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,21 @@
-numpy==1.16.1
-pandas==0.24.1
+numpy==1.17.4
+pandas==0.24.2
 python-dateutil==2.8.0
 pytz==2018.9
-scipy==1.2.1
+scipy==1.3.2
 six==1.12.0
-SQLAlchemy==1.2.17
+SQLAlchemy==1.2.19
 nbval==0.9.1
 # tests
+hypothesis==4.50.2
 pytest==4.4.2
-psycopg2==2.8.2
+psycopg2==2.8.4
 # only used for iris dataset
 scikit-learn==0.20.2
 # used for docs
 nbsphinx==0.4.2
-jupytext==1.1.1
+jupytext==1.3.0
 gapminder==0.1
 matplotlib==3.1.0
 plotnine==0.5.1
+

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,10 @@ setup(
     url='https://github.com/machow/siuba',
     keywords=['package', ],
     install_requires = [
-        "pandas"
+        "pandas>=0.24.0",
+        "numpy>=1.12.0",
+        "SQLAlchemy>=1.1.18",
+        "psycopg2>=2.7.0",
     ],
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,13 @@ setup(
     author_email='mc_al_gh_siuba@fastmail.com',
     url='https://github.com/machow/siuba',
     keywords=['package', ],
-    install_requires = [
+    install_requires=[
         "pandas>=0.24.0",
         "numpy>=1.12.0",
         "SQLAlchemy>=1.1.18",
         "psycopg2>=2.7.0",
     ],
+    python_requires=">=3.6",
     include_package_data=True,
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
This adds python 3.8 to travis, and provides explicit dependency support.

Addresses #154 #161 