### PR TITLE
fix: siu no longer falsey, iterable, and uses hidden properties

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -638,7 +638,7 @@ def _rename(__data, **kwargs):
 
 def _call_strip_ascending(f):
     if isinstance(f, Symbolic):
-        f = f.source
+        f = strip_symbolic(f)
 
     if isinstance(f, Call) and f.func == "__neg__":
         return f.args[0], False

--- a/siuba/siu.py
+++ b/siuba/siu.py
@@ -69,8 +69,8 @@ MISC_OPS = {
 
 ALL_OPS = {**BINARY_OPS, **UNARY_OPS, **MISC_OPS}
 
-for k, v in BINARY_OPS.copy().items():
-    BINARY_OPS[k.replace("__", "__r", 1)] = v
+#for k, v in BINARY_OPS.copy().items():
+#    BINARY_OPS[k.replace("__", "__r", 1)] = v
 
 for k, v in BINARY_LEVELS.copy().items():
     BINARY_LEVELS[k.replace("__", "__r", 1)] = v
@@ -84,7 +84,7 @@ class Formatter:
         
         # TODO: why are some nodes still symbolic?
         if isinstance(call, Symbolic):
-            return self.format(call.source)
+            return self.format(strip_symbolic(call))
 
         if isinstance(call, MetaArg):
             return "_"
@@ -604,8 +604,11 @@ class CallTreeLocal(CallListener):
 
 class Symbolic(object):
     def __init__(self, source = None, ready_to_call = False):
-        self.source = MetaArg("_") if source is None else source
-        self.ready_to_call = ready_to_call
+        self.__source = MetaArg("_") if source is None else source
+        self.__ready_to_call = ready_to_call
+
+
+    # allowed methods ----
 
     def __getattr__(self, x):
         # temporary hack working around ipython pretty.py printing
@@ -613,39 +616,51 @@ class Symbolic(object):
 
         return Symbolic(BinaryOp(
                 "__getattr__",
-                self.source,
+                self.__source,
                 strip_symbolic(x)
                 ))
                 
 
     def __call__(self, *args, **kwargs):
-        if self.ready_to_call:
-            return self.source(*args, **kwargs)
+        if self.__ready_to_call:
+            return self.__source(*args, **kwargs)
 
-        return create_sym_call(self.source, *args, **kwargs)
+        return create_sym_call(self.__source, *args, **kwargs)
 
     def __getitem__(self, *args):
         return Symbolic(Call(
                 "__getitem__",
-                self.source,
+                self.__source,
                 *map(slice_to_call, args)
                 ),
                 ready_to_call = True)
 
     
     def __invert__(self):
-        if isinstance(self.source, Call) and self.source.func == "__invert__":
-            return self.source.args[0]
+        if isinstance(self.__source, Call) and self.__source.func == "__invert__":
+            return self.__source.args[0]
         else: 
             return self.__op_invert()
 
 
     def __op_invert(self):
-        return Symbolic(UnaryOp('__invert__', self.source), ready_to_call = True)
+        return Symbolic(UnaryOp('__invert__', self.__source), ready_to_call = True)
 
+
+    # banned methods ----
+
+    __contains__ = None
+    __iter__ = None
+
+    def __bool__(self):
+        raise TypeError("Symbolic objects can not be converted to True/False, or used "
+                        "with these keywords: not, and, or.")
+
+
+    # representation ----
         
     def __repr__(self):
-        return Formatter().format(self.source)
+        return Formatter().format(self.__source)
 
 
 def create_sym_call(source, *args, **kwargs):
@@ -672,7 +687,7 @@ def str_to_getitem_call(x):
     
 def strip_symbolic(x):
     if isinstance(x, Symbolic):
-        return x.source
+        return x.__dict__["_Symbolic__source"]
 
     return x
 
@@ -680,9 +695,9 @@ def strip_symbolic(x):
 def explain(symbol):
     """Print representation that resembles code used to create symbol."""
     if isinstance(symbol, Symbolic):
-        print(symbol.source)
-    else: 
-        print(symbol)
+        return str(strip_symbolic(symbol))
+
+    return str(symbol)
 
 
 # symbolic dispatch wrapper ---------------------------------------------------
@@ -712,30 +727,32 @@ def symbolic_dispatch(f = None, cls = object):
 
     @dispatch_func.register(Symbolic)
     def _dispatch_symbol(__data, *args, **kwargs):
-        return create_sym_call(FuncArg(dispatch_func), __data.source, *args, **kwargs)
+        return create_sym_call(FuncArg(dispatch_func), strip_symbolic(__data), *args, **kwargs)
 
     @dispatch_func.register(Call)
     def _dispatch_call(__data, *args, **kwargs):
         # TODO: want to just create call, for now use hack of creating a symbolic
         #       call and getting the source off of it...
-        return create_sym_call(FuncArg(dispatch_func), __data, *args, **kwargs).source
+        return strip_symbolic(create_sym_call(FuncArg(dispatch_func), __data, *args, **kwargs))
 
     return dispatch_func
 
     
 # Do some gnarly method setting -----------------------------------------------
 
-def create_binary_op(op_name):
+def create_binary_op(op_name, left_assoc = True):
     def _binary_op(self, x):
-        node = BinaryOp(op_name, self.source, strip_symbolic(x))
+        if left_assoc:
+            node = BinaryOp(op_name, strip_symbolic(self), strip_symbolic(x))
+        else:
+            node = BinaryOp(op_name, strip_symbolic(x), strip_symbolic(self))
 
         return Symbolic(node, ready_to_call = True)
-
     return _binary_op
 
 def create_unary_op(op_name):
     def _unary_op(self):
-        node = UnaryOp(op_name, self.source)
+        node = UnaryOp(op_name, strip_symbolic(self))
 
         return Symbolic(node, ready_to_call = True)
 
@@ -743,8 +760,9 @@ def create_unary_op(op_name):
 
 for k, v in BINARY_OPS.items():
     if k in {"__getattr__"}: continue
-    rop = k.replace("__", "__r")
+    rop = k.replace("__", "__r", 1)
     setattr(Symbolic, k, create_binary_op(k))
+    setattr(Symbolic, rop, create_binary_op(k, left_assoc = False))
 
 for k, v in UNARY_OPS.items():
     if k != "__invert__":

--- a/siuba/spec/series.py
+++ b/siuba/spec/series.py
@@ -135,7 +135,6 @@ funcs = {
         'iat': _.iat[1]            >> Todo(),
         'loc': _.loc[1]            >> Todo(),
         'iloc': _.iloc[1]          >> Todo(),
-        '__iter__': _.__iter__()   >> Maydo(),
         'items': _.items()         >> Wontdo(),
         'iteritems': _.iteritems() >> Wontdo(),
         'keys': _.keys()           >> Wontdo(),

--- a/siuba/spec/utils.py
+++ b/siuba/spec/utils.py
@@ -2,7 +2,9 @@ from siuba.siu import _, MetaArg, strip_symbolic
 import itertools
 
 def get_type_info(call):
-    if call.func != "__rshift__":
+    call = strip_symbolic(call)
+    func = call.func
+    if isinstance(func, str) and func != "__rshift__":
         raise ValueError("Expected first expressions was >>")
         
     out = {}

--- a/siuba/tests/test_siu.py
+++ b/siuba/tests/test_siu.py
@@ -1,8 +1,97 @@
-from siuba.siu import _, strip_symbolic, FunctionLookupError, Symbolic, MetaArg
+from siuba.siu import strip_symbolic, FunctionLookupError, Symbolic, MetaArg
 import pytest
 
-def test_op_vars_slice():
+@pytest.fixture
+def _():
+    return Symbolic()
+
+def test_source_attr(_):
+    sym = _.source
+    assert isinstance(sym, Symbolic)
+    assert explain(sym) == "_.source"
+
+def test_op_vars_slice(_):
     assert strip_symbolic(_.a[_.b:_.c]).op_vars() == {'a', 'b', 'c'}
+
+# Truthiness should raise TypeError -------------------------------------------
+
+import operator as op
+
+@pytest.mark.parametrize('f, arg', [
+    (op.contains, 'x'),
+    (op.not_,None),
+    (op.truth,None),
+    (iter,None),
+    ])
+def test_siu_not_truth_value(_, f, arg):
+    with pytest.raises(TypeError):
+        f(_) if arg  is None else f(_, arg)
+        f(_, arg)
+    
+def test_siu_not_truth_value_keywords(_):
+    with pytest.raises(TypeError):
+        _ and True
+
+    with pytest.raises(TypeError):
+        _ or True
+
+
+# Explain  --------------------------------------------------------------------
+
+from siuba.siu import explain
+
+@pytest.mark.parametrize('code', [
+    "-_",
+    "+_",
+    #abs,
+    "~_",
+    #complex,
+    #int,
+    #long,
+    #float,
+    #oct,
+    #hex,
+    #index,
+    #round,
+    #math.trunc
+    #math.floor
+    #math.ceil
+
+    ])
+def test_explain_unary(_, code):
+    sym = eval(code, {'_': _})
+
+    assert explain(sym) == code
+
+@pytest.mark.parametrize('op', [
+    "+",
+    "-",
+    "*",
+    "@",
+    "//",
+    #truediv
+    #divmod
+    "/",
+    "%",
+    #"_ ** _", #TODO: uses different formatting
+    "<<",
+    ">>",
+    "&",
+    "^",
+    "|"
+    ])
+def test_explain_binary(_, op):
+    left = "_ {op} 1".format(op = op)
+    sym = eval(left, {'_': _})
+
+    assert explain(sym) == left
+
+    right = "1 {op} _".format(op = op)
+    sym = eval(right, {'_': _})
+
+    assert explain(sym) == right
+
+
 
 # Symbolic dispatch ===========================================================
 from siuba.siu import symbolic_dispatch, Call, FuncArg
@@ -24,7 +113,7 @@ def test_FuncArg_in_call():
 
 
 
-def test_symbolic_dispatch():
+def test_symbolic_dispatch(_):
     @symbolic_dispatch
     def f(x, y = 2):
         return x + y
@@ -54,28 +143,28 @@ def ctl():
     yield CallTreeLocal(local, call_sub_attr = ('str', 'dt'))
 
 
-def test_call_tree_local_sub_attr_method(ctl):
+def test_call_tree_local_sub_attr_method(_, ctl):
     # sub attr gets stripped w/ method call
     call = ctl.enter(strip_symbolic(_.str.f_a()))
     assert call('x') == 'x'
 
-def test_call_tree_local_sub_attr_property(ctl):
+def test_call_tree_local_sub_attr_property(_, ctl):
     # sub attr gets stripped w/ property access
     call = ctl.enter(strip_symbolic(_.str.f_a))
     assert call('x') == 'x'
 
-def test_call_tree_local_sub_attr_alone(ctl):
+def test_call_tree_local_sub_attr_alone(_, ctl):
     # attr alone is treated like a normal getattr
     call = ctl.enter(strip_symbolic(_.str))
     assert call.func == "__getattr__"
     assert call.args[1] == "str"
 
-def test_call_tree_local_sub_attr_method_missing(ctl):
+def test_call_tree_local_sub_attr_method_missing(_, ctl):
     # subattr raises lookup errors (method)
     with pytest.raises(FunctionLookupError):
         ctl.enter(strip_symbolic(_.str.f_b()))
 
-def test_call_tree_local_sub_attr_property_missing(ctl):
+def test_call_tree_local_sub_attr_property_missing(_, ctl):
     # subattr raises lookup errors (property)
     with pytest.raises(FunctionLookupError):
         ctl.enter(strip_symbolic(_.str.f_b))
@@ -148,4 +237,3 @@ def test_call_tree_local_dispatch_fail(f_dispatch_strict):
     new_call = ctl.enter(call)
     with pytest.raises(TypeError):
         new_call('na')
- 


### PR DESCRIPTION
Addresses #131

Resolves the following issues, by disabling their methods on the `Symbolic` object:

```python
from siuba import _

# produced _[0]
next(iter(_))

# also meant this ran forever..
for ii in _: pass

# used to return False. Can only return bool or raise
'a' in _

# used to return the symbol: _.a
_.a.source
```

Note that this brings the symbols behavior strongly in line with numpy arrays and pandas series