### PR TITLE
Feat floor date

### DIFF
--- a/siuba/experimental/datetime.py
+++ b/siuba/experimental/datetime.py
@@ -1,0 +1,114 @@
+from siuba.siu import symbolic_dispatch
+from pandas.arrays import DatetimeArray, PeriodArray
+from pandas import DatetimeIndex, PeriodIndex, Period, Timestamp, Series
+
+from pandas import offsets
+from pandas.core.dtypes.common import is_period_dtype, is_datetime64_any_dtype
+
+from abc import ABC
+
+LUBRIDATE_OFFSETS = {
+        "second": "S",
+        "minute": "M",
+        "hour": "H",
+        "day": "D",
+        "week": "W",
+        "month": "M",
+        "bimonth": "2M",
+        "quarter": "Q",
+        "season": None,
+        "halfyear": None,
+        "year": "Y"
+        }
+
+# There's no class that clearly identifies all the Datetime op compatible classes,
+# so make an ABC and register them on it
+def _make_abc(name, subclasses):
+    cls = type(name, (ABC,), {})
+    for child in subclasses: cls.register(child)
+    return cls
+
+DatetimeType = _make_abc("DatetimeType", [DatetimeIndex, DatetimeArray, Timestamp])
+PeriodType   = _make_abc("PeriodType",   [PeriodIndex, PeriodArray, Period])
+
+def _get_offset(unit):
+    cls = offsets.prefix_mapping.get(unit)
+    if cls is None:
+        raise ValueError("unit {} not a valid offset".format(unit))
+
+    return cls
+
+def _get_series_dispatcher(f, x):
+    if is_period_dtype(x):
+        return f.registry[PeriodType]
+    elif is_datetime64_any_dtype(x):
+        return f.registry[DatetimeType]
+
+    raise TypeError("does not seem to be a period or datetime")
+
+
+# Floor date ------------------------------------------------------------------
+
+@symbolic_dispatch
+def floor_date(x, unit = "S"):
+    raise TypeError("floor_date not implemented for class {}".format(type(x)))
+
+
+@floor_date.register(DatetimeType)
+def _(x, unit = "S"):
+    cls_offset = _get_offset(unit)
+
+    if issubclass(cls_offset, offsets.Tick):
+        return x.floor(unit)
+
+    # note: x - 0*offset shifts anchor forward for some reason, so we
+    # add then subtract to ensure it doesn't change anchor points
+    offset = cls_offset(n = 1)
+    return x.normalize() + offset - offset          
+
+
+@floor_date.register(PeriodType)
+def _(x, unit = "S"):
+    return x.asfreq(unit, how = "start")
+
+
+@floor_date.register(Series)
+def _(x, *args, **kwargs):
+    # dispatch to either period or datetime version
+    f = _get_series_dispatcher(floor_date, x)
+    return f(x.dt, *args, **kwargs)
+
+
+# Ceil date -------------------------------------------------------------------
+ 
+@symbolic_dispatch
+def ceil_date(x, unit = "S"):
+    raise TypeError("ceil_date not implemented for class {}".format(type(x)))
+
+
+@ceil_date.register(DatetimeType)
+def _(x, unit = "S"):
+    cls_offset = _get_offset(unit)
+
+    if issubclass(cls_offset, offsets.Tick):
+        return x.ceil(unit)
+
+    offset = cls_offset(n = 0)
+    # the 0 ensures it will not rollforward an anchor point
+    return x.normalize() + offset
+
+
+@ceil_date.register(PeriodType)
+def _(x, unit = "S"):
+    raise NotImplementedError(
+            "It is not possible to use ceil_date on a Period. "
+            "Try converting to a DatetimeIndex."
+            )
+
+
+@ceil_date.register(Series)
+def _(x, *args, **kwargs):
+    f = _get_series_dispatcher(ceil_date, x)
+    return f(x.dt, *args, **kwargs)
+
+

--- a/siuba/experimental/datetime.py
+++ b/siuba/experimental/datetime.py
@@ -46,13 +46,75 @@ def _get_series_dispatcher(f, x):
 
     raise TypeError("does not seem to be a period or datetime")
 
+DOCSTRING = """
+    floor_date and ceil_date return dates rounded to nearest specified unit.
 
-# Floor date ------------------------------------------------------------------
+    Args:
+        x: a DatetimeIndex, PeriodIndex, or their underlying arrays or elements.
+        units: a date or time unit for rounding (eg. "MS" rounds down or up to the start of a month)
+
+    Note:
+        For a full list of units run the following:
+        
+        :: 
+            from pandas.tseries.offsets import prefix_mapping
+        
+        Common time units include seconds (S), minute (T), hour (H), week (W). 
+        Some date units are month end (M), month start (MS), year start (AS)
+
+
+    The main feature of floor_date is that it works on things like Months, which is
+    not supported in the floor method.
+
+    >>> import pandas as pd
+    >>> a_date = "2020-02-02 02:02:02"
+    >>> dti = pd.DatetimeIndex([a_date])
+    >>> dti.floor("MS")
+    Traceback (most recent call last):
+    ...
+    ValueError: <MonthBegin> is a non-fixed frequency
+
+    >>> floor_date(dti, "MS")       # round down to month start
+    DatetimeIndex(['2020-02-01'], dtype='datetime64[ns]', freq=None)
+
+    >>> ceil_date(dti, "MS")
+    DatetimeIndex(['2020-03-01'], dtype='datetime64[ns]', freq=None)
+
+    >>> floor_date(dti, "M")        # round down to month end
+    DatetimeIndex(['2020-01-31'], dtype='datetime64[ns]', freq=None)
+
+    >>> ceil_date(dti, "M")
+    DatetimeIndex(['2020-02-29'], dtype='datetime64[ns]', freq=None)
+
+    It also works on things supported by the Series.dt.floor method, like hours.
+
+    >>> floor_date(dti, "H")        # round down to hour
+    DatetimeIndex(['2020-02-02 02:00:00'], dtype='datetime64[ns]', freq=None)
+
+    You can also use it on other types, like a PeriodIndex
+
+    >>> per = pd.PeriodIndex([a_date], freq = "S")
+    >>> floor_date(per, "M")
+    PeriodIndex(['2020-02'], dtype='period[M]', freq='M')
+
+"""
+
+# Create single dispatch functions --------------------------------------------
 
 @symbolic_dispatch
 def floor_date(x, unit = "S"):
     raise TypeError("floor_date not implemented for class {}".format(type(x)))
 
+
+@symbolic_dispatch
+def ceil_date(x, unit = "S"):
+    raise TypeError("ceil_date not implemented for class {}".format(type(x)))
+
+floor_date.__doc__ = DOCSTRING
+ceil_date.__doc__  = DOCSTRING
+
+
+# Floor date ------------------------------------------------------------------
 
 @floor_date.register(DatetimeType)
 def _(x, unit = "S"):
@@ -81,11 +143,6 @@ def _(x, *args, **kwargs):
 
 # Ceil date -------------------------------------------------------------------
  
-@symbolic_dispatch
-def ceil_date(x, unit = "S"):
-    raise TypeError("ceil_date not implemented for class {}".format(type(x)))
-
-
 @ceil_date.register(DatetimeType)
 def _(x, unit = "S"):
     cls_offset = _get_offset(unit)

--- a/siuba/experimental/datetime.py
+++ b/siuba/experimental/datetime.py
@@ -74,13 +74,17 @@ DOCSTRING = """
     ...
     ValueError: <MonthBegin> is a non-fixed frequency
 
-    >>> floor_date(dti, "MS")       # round down to month start
+    Month start will always go to the first day of a month.
+
+    >>> floor_date(dti, "MS") 
     DatetimeIndex(['2020-02-01'], dtype='datetime64[ns]', freq=None)
 
     >>> ceil_date(dti, "MS")
     DatetimeIndex(['2020-03-01'], dtype='datetime64[ns]', freq=None)
 
-    >>> floor_date(dti, "M")        # round down to month end
+    On the other hand, here is month end.
+    
+    >>> floor_date(dti, "M") 
     DatetimeIndex(['2020-01-31'], dtype='datetime64[ns]', freq=None)
 
     >>> ceil_date(dti, "M")
@@ -88,7 +92,7 @@ DOCSTRING = """
 
     It also works on things supported by the Series.dt.floor method, like hours.
 
-    >>> floor_date(dti, "H")        # round down to hour
+    >>> floor_date(dti, "H")
     DatetimeIndex(['2020-02-02 02:00:00'], dtype='datetime64[ns]', freq=None)
 
     You can also use it on other types, like a PeriodIndex

--- a/siuba/tests/test_dply_datetime.py
+++ b/siuba/tests/test_dply_datetime.py
@@ -1,0 +1,98 @@
+from pandas.tseries.offsets import Nano, Day, Hour, MonthEnd
+from pandas import Timestamp
+import pandas as pd
+from pandas.core.arrays import DatetimeArray
+
+import pandas.testing as tm
+from pandas import offsets
+from siuba.dply.dt import floor_date, ceil_date
+
+import pytest
+
+# TODO: currently testing only DatetimeIndex, also need to test PeriodIndex
+#       and the array classes
+
+def check_floor_ceil(src, offset, unit):
+    # Test DatetimeIndex
+    res_low = floor_date(src + offset, unit)
+    res_hi  = ceil_date(src - offset, unit)
+
+    tm.assert_index_equal(res_low, src)
+    tm.assert_index_equal(res_hi, src)
+
+    # Test series ----
+    ser_src = pd.Series(src)
+    ser_low = floor_date(ser_src + offset, unit)
+    ser_hi =  ceil_date(ser_src - offset, unit)
+
+    tm.assert_series_equal(ser_low, ser_src)
+    tm.assert_series_equal(ser_hi, ser_src)
+
+@pytest.mark.parametrize("unit", [
+    "S",
+    "D"
+    ])
+def test_tick(unit):
+    src = pd.DatetimeIndex(["2020-01-02"])
+    check_floor_ceil(src, Nano(), unit)
+
+
+@pytest.mark.parametrize("offset", [Nano(), Day(), Hour()])
+def test_nonperiodic_month(offset):
+    src  = pd.DatetimeIndex(["2020-02-01"]) 
+    check_floor_ceil(src, offset, "MS")
+
+
+@pytest.mark.parametrize("offset", [Nano(), Day(), Hour()])
+def test_floor_nonperiodic_month_end(offset):
+    src  = pd.DatetimeIndex(["2020-01-31"]) 
+    check_floor_ceil(src, offset, "M")
+
+
+@pytest.mark.parametrize("offset", [Nano(), Day(), Hour(), MonthEnd()])
+def test_floor_nonperiodic_year(offset):
+    src = pd.DatetimeIndex(["2020-01-01"]) 
+    check_floor_ceil(src, offset, "AS")
+
+
+@pytest.mark.parametrize("offset", [Nano(), Day(), Hour(), MonthEnd()])
+def test_floor_nonperiodic_year_end(offset):
+    src = pd.DatetimeIndex(["2019-12-31"]) 
+    check_floor_ceil(src, offset, "A")
+
+def test_floor_anchor():
+    src = pd.DatetimeIndex(["2020-02-01"])
+    res = floor_date(src, "MS")
+
+    tm.assert_index_equal(res, src)
+
+
+def test_floor_idempotent():
+    src = pd.DatetimeIndex(["2020-02-01"])
+    res = floor_date(floor_date(src + Day(), "MS"), "MS")
+
+    tm.assert_index_equal(res, src)
+
+
+def test_ceil_idempotent():
+    src = pd.DatetimeIndex(["2020-02-01"])
+    res = ceil_date(ceil_date(src - Day(), "MS"), "MS")
+
+    tm.assert_index_equal(res, src)
+
+# Period ----
+
+@pytest.mark.parametrize("unit", [
+    "S",
+    "D",
+    "M"
+    ])
+def test_period_floor_tick(unit):
+    src = pd.DatetimeIndex(["2020-01-02"])
+    res = floor_date((src + Nano()).to_period("ns"), unit)
+    tm.assert_index_equal(res, src.to_period(unit))
+
+
+def test_period_ceil_fail():
+    with pytest.raises(NotImplementedError):
+        ceil_date(pd.PeriodIndex(["2020-01-01"], freq = "D"), "D")

--- a/siuba/tests/test_dply_datetime.py
+++ b/siuba/tests/test_dply_datetime.py
@@ -5,7 +5,7 @@ from pandas.core.arrays import DatetimeArray
 
 import pandas.testing as tm
 from pandas import offsets
-from siuba.dply.dt import floor_date, ceil_date
+from siuba.experimental.datetime import floor_date, ceil_date
 
 import pytest
 


### PR DESCRIPTION
Adds two new single dispatch functions: floor_date() and ceil_date(). These are put in experimental for now.

```python
from siuba.experimental.datetime import floor_date, ceil_date
import pandas as pd

import pandas as pd
a_date = "2020-02-02 02:02:02"
dti = pd.DatetimeIndex([a_date])

floor_date(dti, "MS")
#DatetimeIndex(['2020-02-01'], dtype='datetime64[ns]', freq=None)

floor_date(dti, "M")
#DatetimeIndex(['2020-01-31'], dtype='datetime64[ns]', freq=None)
```