### PR TITLE
[WIP] Switched pivot_longer to stack, and stubbed out some more tests

### DIFF
--- a/siuba/experimental/pivot/__init__.py
+++ b/siuba/experimental/pivot/__init__.py
@@ -1,27 +1,42 @@
-from siuba.dply.verbs import singledispatch2, gather, var_create, var_select
 import pandas as pd
 import numpy as np
 
-def pivot_longer_spec(data, spec, names_repair = "check_unique", values_drop_na = False):
+from typing import Union, Tuple, Dict, Optional
+
+from siuba.dply.verbs import singledispatch2, gather, var_create, var_select
+
+
+def pivot_longer_spec(data,
+                      spec,
+                      names_repair: Optional[str] = "check_unique",
+                      values_drop_na: bool = False):
     pass
+
 
 @singledispatch2(pd.DataFrame)
 def pivot_longer(
         __data,
         *args,
-        names_to = "name",
-        names_prefix = None,
-        names_sep = None,
-        names_pattern = None,
-        names_ptypes = tuple(),
-        names_repair = "check_unique",
-        values_to = "value",
-        values_drop_na = False,
-        values_ptypes = tuple(),
-        values_transform = dict(),
+        names_to: Union[str, Tuple[str, ...]] = "name",
+        names_prefix: Optional[str] = None,
+        names_sep: Optional[str] = None,
+        names_pattern: Optional[str] = None,
+        names_ptypes: Optional[Tuple] = None,
+        names_repair: str = "check_unique",
+        values_to: str = "value",
+        values_drop_na: bool = False,
+        values_ptypes: Optional[Union[str, Tuple[str, ...]]] = None,
+        values_transform: Optional[Dict] = dict(),
         ):
     
-    # Copied selection over from gather, maybe this can be compartmentalised away?
+    if names_sep is not None and names_pattern is not None:
+        raise ValueError("You may only use either `names_sep` or "
+                         "`names_pattern`.")
+
+    if isinstance(names_to, str):
+        names_to = (names_to,)
+
+    # Copied selection over from gather, maybe this can be compartmentalised?
     var_list = var_create(*args)
     od = var_select(__data.columns, *var_list)
 
@@ -35,13 +50,61 @@ def pivot_longer(
         # original dataframe. To copy tidyr behaviour, we need to raise a
         # ValueError
         # stacked = __data.stack(dropna=values_drop_na)
-        raise ValueError("Please provide at least 1 column or all columns (shorthand: _[:]).")
+        raise ValueError("Please provide at least 1 column or all columns "
+                         "(shorthand: _[:]).")
+    elif names_sep is not None or names_pattern is not None:
+        to_stack = __data.loc[:,value_vars]
+        column_index = (
+            to_stack.columns.str.split(names_sep).map(tuple)
+            if names_sep is not None
+            # Split by names_pattern, and remove empty strings using filter
+            else to_stack.columns.str.split(names_pattern).map(
+                lambda x: tuple(list(filter(None, x)))
+            )
+        )
+        split_lengths = np.array(column_index.map(len))
+
+        if not np.all(split_lengths == split_lengths[0]):
+            raise ValueError(
+                    "Splitting by {} leads to unequal lenghts ({}).".format(
+                        names_sep if names_sep is not None else names_pattern
+                    )
+                )
+        
+        if split_lengths[0] != len(names_to):
+            raise ValueError("Splitting provided more values than provided in "
+                             "`names_to`")
+        
+        # TODO: To set names for the new index, we need to feed in a list.
+        # There's no particular reason to use a tuples as input in the first
+        # place, might be worth reconsidering the choice of input format?
+        # TODO: What if we don't use '_value' in the tuple? Need to check tidyr
+        stack_idx = (
+            [i for i, x in enumerate(list(names_to)) if x != "_value"]
+            if names_to != ('_value',)
+            else -1
+        )
+        names_to = [x if x != "_value" else None for x in names_to]
+
+        column_index = column_index.set_names(names_to)
+
+        to_stack.columns = column_index
+        stacked = to_stack.stack(stack_idx)
+        stacked = stacked.reset_index(level=stacked.index.nlevels - 1)
+
+        if stack_idx == -1:
+            stacked = stacked.drop(columns='level_1')
+        if np.nan in names_to:
+            stacked = stacked.drop(columns=[np.nan])
+        if values_drop_na:
+            stacked = stacked.dropna(axis = 1)
     else:
         stacked = __data.loc[:,value_vars].stack(dropna=values_drop_na)
-    
-    # Set column names for stack
-    stacked.index.rename(names_to, level=1, inplace=True)
-    stacked.name = values_to
+        # Set column names for stack
+        # As in tidyr `values_to` is ignored if `names_sep` or `names_pattern`
+        # is provided.
+        stacked.index.rename(names_to[0], level=1, inplace=True)
+        stacked.name = values_to
 
     # values_transform was introduced in tidyr 1.1.0
     if values_to in values_transform:
@@ -53,13 +116,22 @@ def pivot_longer(
         else:
             stacked = stacked.apply(lambda x: values_transform[values_to](x))
 
-    stacked_df = stacked.reset_index(1)
+    stacked_df = (
+        # if `names_sep` or `names_pattern` are not provided `stacked` will
+        # be a pd.Series and needs its index reset.
+        stacked.reset_index(1)
+        if names_sep is None and names_pattern is None
+        else stacked
+    )
 
-    # If we want to pivot all but one, we are left with a pd.Series
-    # This needs to be converted to a DataFrame to serve as left element in a merge
+    # If we want to pivot all but one, we are left with a `pd.Series`.
+    # This needs to be converted to a DataFrame to serve as left element in a
+    # merge
     if isinstance(keep_data, pd.Series):
         output_df = keep_data.to_frame().merge(stacked_df, left_index=True, right_index=True)
+    elif keep_data.empty:
+        output_df = stacked_df
     else:
         output_df = keep_data.merge(stacked_df, left_index=True, right_index=True)
-
+    
     return output_df

--- a/siuba/experimental/pivot/__init__.py
+++ b/siuba/experimental/pivot/__init__.py
@@ -1,5 +1,6 @@
-from siuba.dply.verbs import singledispatch2, gather
+from siuba.dply.verbs import singledispatch2, gather, var_create, var_select
 import pandas as pd
+import numpy as np
 
 def pivot_longer_spec(data, spec, names_repair = "check_unique", values_drop_na = False):
     pass
@@ -7,7 +8,7 @@ def pivot_longer_spec(data, spec, names_repair = "check_unique", values_drop_na 
 @singledispatch2(pd.DataFrame)
 def pivot_longer(
         __data,
-        cols,
+        *args,
         names_to = "name",
         names_prefix = None,
         names_sep = None,
@@ -16,6 +17,45 @@ def pivot_longer(
         names_repair = "check_unique",
         values_to = "value",
         values_drop_na = False,
-        values_ptypes = tuple()
+        values_ptypes = tuple(),
+        values_transform = dict(),
         ):
-    return gather(__data, names_to, values_to, cols)
+    
+    # Copied selection over from gather, maybe this can be compartmentalised away?
+    var_list = var_create(*args)
+    od = var_select(__data.columns, *var_list)
+
+    value_vars = list(od) or None
+
+    id_vars = [col for col in __data.columns if col not in od]
+
+    keep_data = __data.loc[:,id_vars]
+    if value_vars is None:
+        stacked = __data.stack(dropna=values_drop_na)
+    else:
+        stacked = __data.loc[:,value_vars].stack(dropna=values_drop_na)
+    
+    # Set column names for stack
+    stacked.index.rename(names_to, level=1, inplace=True)
+    stacked.name = values_to
+
+    # values_transform was introduced in tidyr 1.1.0
+    if values_to in values_transform:
+        # TODO: error handling -- this won't work for dictionaries
+        # list needs special handling, as it can only be applied to iterables,
+        # not integers.
+        if values_transform[values_to] == list:
+            stacked = stacked.apply(lambda x: [x])
+        else:
+            stacked = stacked.apply(lambda x: values_transform[values_to](x))
+
+    stacked_df = stacked.reset_index(1)
+
+    # If we want to pivot all but one, we are left with a pd.Series
+    # This needs to be converted to a DataFrame to serve as left element in a merge
+    if isinstance(keep_data, pd.Series):
+        output_df = keep_data.to_frame().merge(stacked_df, left_index=True, right_index=True)
+    else:
+        output_df = keep_data.merge(stacked_df, left_index=True, right_index=True)
+
+    return output_df

--- a/siuba/experimental/pivot/__init__.py
+++ b/siuba/experimental/pivot/__init__.py
@@ -31,7 +31,11 @@ def pivot_longer(
 
     keep_data = __data.loc[:,id_vars]
     if value_vars is None:
-        stacked = __data.stack(dropna=values_drop_na)
+        # While stack works in this case, it will later on merge in to the
+        # original dataframe. To copy tidyr behaviour, we need to raise a
+        # ValueError
+        # stacked = __data.stack(dropna=values_drop_na)
+        raise ValueError("Please provide at least 1 column or all columns (shorthand: _[:]).")
     else:
         stacked = __data.loc[:,value_vars].stack(dropna=values_drop_na)
     

--- a/siuba/experimental/pivot/test_pivot.py
+++ b/siuba/experimental/pivot/test_pivot.py
@@ -7,13 +7,18 @@ https://github.com/tidyverse/tidyr/blob/master/tests/testthat/test-pivot-long.R
 # TODO: pivot_longer rows in different order from gather. Currently using
 #       a row order invariant form of test. Should fix to conform to pivot_longer.
 # TODO: need to be careful about index. Should preserve original indices for rows.
+# TODO: Current behaviour of pivot_longer is to preserve the index. Therefore
+#       it needs to be reset for any assertion.
 
 from . import pivot_longer, pivot_longer_spec
 
 import pytest
+import pandas as pd
+import numpy as np
 from siuba.siu import Symbolic
 from siuba.tests.helpers import data_frame, assert_frame_sort_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
+
 
 _ = Symbolic()
 
@@ -26,16 +31,16 @@ def test_pivot_all_cols_to_long():
     
     res = pivot_longer(src, _["x":"y"])
 
-    assert_frame_sort_equal(res, dst)
+    assert_frame_equal(res.reset_index(drop=True), dst)
 
 
-@pytest.mark.xfail
 def test_values_interleaved_correctly():
     # TODO: fix order issue
     df = data_frame(x = [1,2], y = [10, 20], z = [100, 200])
 
     pv = pivot_longer(df, _[0:3])
     assert pv["value"].tolist() == [1, 10, 100, 2, 20, 200]
+
 
 @pytest.mark.xfail
 def test_spec_add_multi_columns():
@@ -46,15 +51,97 @@ def test_spec_add_multi_columns():
     pv = pivot_longer_spec(df, spec = sp)
 
     assert pv.columns.tolist() == ["a", "b", "v"]
-    
-@pytest.mark.xfail
+
+
 def test_preserves_original_keys():
-    df = data_frame(x = [1,2], y = 2, z = [1,2])
+    df = data_frame(x = [1,2], y = [2,2], z = [1,2])
     pv = pivot_longer(df, _["y":"z"])
 
     assert pv.columns.tolist() == ["x", "name", "value"]
-    assert assert_series_equal(
-            pv["x"],
-            pd.Series(df["x"].repeat(2))
-            )
+    assert_series_equal(
+        pv["x"],
+        pd.Series(df["x"].repeat(2))
+        )
 
+
+def test_can_drop_missing_values():
+    df = data_frame(x = [1, np.nan], y = [np.nan, 2])
+    pv = pivot_longer(df, _["x":"y"], values_drop_na=True)
+
+    assert pv["name"].tolist() == ["x", "y"]
+    assert pv["value"].tolist() == [1, 2]
+
+
+@pytest.mark.xfail
+def test_can_handle_missing_combinations():
+    df = data_frame(id = ["A", "B"], x_1 = [1, 3], x_2 = [2, 4], y_1 = ["a", "b"])
+    pv = pivot_longer(df, -_.id, names_to = ("_value", "n"), names_sep = "_")
+
+    assert pv.columns.tolist() == ["id", "n", "x", "y"]
+    assert pv["x"].tolist() == [1, 2, 3, 4]
+    assert pv["y"].tolist() == [np.nan, "a", np.nan, "b"]
+
+
+@pytest.mark.xfail
+def test_mixed_columns_are_auto_coerced():
+    # TODO: pandas stack (and melt) coerces categorical data when stacking.
+    df = data_frame(x = pd.Categorical(["a"]), y = pd.Categorical(["b"]))
+    pv = pivot_longer(df, _["x":"y"])
+
+    assert_series_equal(pv["value"], pd.Categorical(['a', 'b']))
+
+
+def test_can_override_default_output_col_type():
+    df = data_frame(x = "x", y = 1)
+    pv = pivot_longer(df, _["x":"y"], values_transform = {"value": list})
+
+    assert pv["value"].tolist() == [["x"], [1]]
+
+
+@pytest.mark.xfail
+def test_spec_can_pivot_to_multi_measure_cols():
+    df = data_frame(x = "x", y = 1)
+    sp = data_frame(_name = ["x", "y"], _value = ["X", "Y"], row = [1, 1])
+
+    pv = pivot_longer_spec(df, sp)
+
+    assert pv.columns.tolist() == ["row", "X", "Y"]
+    assert pv["X"] == "x"
+    assert pv["Y"] == 1
+
+
+@pytest.mark.xfail
+def test_original_col_order_is_preserved():
+    df = data_frame(id = ["A", "B"],
+        z_1 = [1, 7], y_1 = [2, 8], x_1 = [3, 9],
+        z_2 = [4, 10], y_2 = [5, 11], x_2 = [6, 12]
+    )
+    pv = pivot_longer(df, -_.id, names_to = ("_value", "n"), names_sep = "_")
+
+    assert pv.columns.tolist() == ["id", "n", "z", "y", "x"]
+
+
+def test_handles_duplicate_column_names():
+    # Cannot initiate data_frame with duplicate keys
+    # df = data_frame(x = 1, a = 1, a = 2, b = 3, b = 4)
+    df = pd.DataFrame.from_records(
+        [(1, 1, 2, 3, 4)], columns = ["x", "a", "a", "b", "b"]
+    )
+    pv = pivot_longer(df, -_.x)
+
+    assert pv.columns.tolist() == ["x", "name", "value"]
+    assert pv["name"].tolist() == ["a", "a", "b", "b"]
+    assert pv["value"].tolist() == [1, 2, 3, 4]
+
+
+@pytest.mark.xfail
+def test_can_pivot_duplicate_names_to_value():
+    df = data_frame(x = 1, a_1 = 1, a_2 = 2, b_1 = 3, b_2 = 4)
+    pv1 = pivot_longer(df, -_.x, names_to = ("_value", np.nan), names_sep = "_")
+    pv2 = pivot_longer(df, -_.x, names_to = ("_value", np.nan), names_pattern = "(.)_(.)")
+    pv3 = pivot_longer(df, -_.x, names_to = "_value", names_pattern = "(.)_(.)")
+
+    assert pv1.columns.tolist() == ["x", "a", "b"]
+    assert pv1["a"] == [1, 2]
+    assert_frame_equal(pv2, pv1)
+    assert_frame_equal(pv3, pv1)


### PR DESCRIPTION
Some tests are still failing (I kept `xfail` on those, and removed the decorator from others).
Essentially the ones that are failing are the ones that require `names_sep`, and `pivot_longer_spec`. I'm still missing 3 more tests until the `build_longer_spec` section, but will add them as we go along.

Current plan:
- [x] Add remaining tests
- [x] Implement `names_sep`
- [ ] Implement `pivot_longer_spec`
- [ ] On to `pivot_wider`