### PR TITLE
tests: travis-ci only tests latest deps on latest branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
       - pip install -r requirements-test.txt
       - pip install . numpy==1.17.4 pandas~=0.25.3 SQLAlchemy~=1.3.11 psycopg2~=2.8.4
   - name: "Pure setup.py install"
+    if: branch = latest
     install:
       - pip install -r requirements-test.txt
       - pip install ./


### PR DESCRIPTION
Small change so I can test siuba everyday on travis for this case: user pip installs siuba with latest dependencies. This means it will test against pandas versions the day they are released. I set it to only run on the "latest" branch, so that tests run on other branches are only those using specified versions for requirements.