### PR TITLE
fix: pandas anti-join breaks when on is string

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -1099,6 +1099,8 @@ def anti_join(left, right = None, on = None):
     # copied from semi_join
     if isinstance(on, Mapping):
         left_on, right_on = zip(*on.items())
+    else: 
+        left_on = right_on = on
 
     # manually perform merge, up to getting pieces need for indexing
     merger = _MergeOperation(left, right, left_on = left_on, right_on = right_on)

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -166,19 +166,20 @@ def test_semi_join_no_cross(backend, df1, df2):
             DF1.iloc[:1,]
             )
 
-def test_basic_anti_join(backend, df1, df2):
+
+def test_basic_anti_join_on_map(backend, df1, df2):
     assert_frame_sort_equal(
             anti_join(df1, df2, on = {"ii": "ii"}) >> collect(),
             DF1.iloc[2:,]
             )
 
-def test_basic_anti_join(backend, df1, df2):
+def test_basic_anti_join_on_str(backend, df1, df2):
     assert_frame_sort_equal(
-            anti_join(df1, df2, on = {"ii": "ii"}) >> collect(),
+            anti_join(df1, df2, on = "ii") >> collect(),
             DF1.iloc[2:,]
             )
-
-def test_basic_anti_join(backend, df1, df2):
+    
+def test_basic_anti_join_on_multi(backend, df1, df2):
     assert_frame_sort_equal(
             anti_join(df1, df2, on = {"ii": "ii", "x": "y"}) >> collect(),
             DF1.iloc[2:,]


### PR DESCRIPTION
e.g. this type on argument always failed: `anti_join(table1, table2, on = "some_key")`