### PR TITLE
fix: sql join order by fix, filter multiple args fix

### DIFF
--- a/siuba/tests/test_verb_filter.py
+++ b/siuba/tests/test_verb_filter.py
@@ -25,8 +25,12 @@ def test_filter_basic(backend):
 
     assert_equal_query(dfs, filter(_.x > 3), df[lambda _: _.x > 3])
 
+def test_filter_basic_two_args(backend):
+    df = data_frame(x = [1,2,3,4,5], y = [5,4,3,2,1])
+    dfs = backend.load_df(df)
 
-@backend_sql("TODO: pandas - grouped col should be first after mutate")
+    assert_equal_query(dfs, filter(_.x > 3, _.y < 2), df[lambda _: (_.x > 3) & (_.y < 2)])
+
 @backend_notimpl("sqlite")
 def test_filter_via_group_by(backend):
     df = data_frame(
@@ -43,7 +47,6 @@ def test_filter_via_group_by(backend):
             )
 
 
-@backend_sql("TODO: pandas - grouped col should be first after mutate")
 @backend_notimpl("sqlite")
 def test_filter_via_group_by_agg(backend):
     dfs = backend.load_df(x = range(1,11), g = [1]*5 + [2]*5)
@@ -53,6 +56,18 @@ def test_filter_via_group_by_agg(backend):
             group_by(_.g) >> filter(_.x > _.x.mean()),
             data_frame(x = [4, 5, 9, 10], g = [1, 1, 2, 2])
             )
+
+
+@backend_notimpl("sqlite")
+def test_filter_via_group_by_agg_two_args(backend):
+    dfs = backend.load_df(x = range(1,11), g = [1]*5 + [2]*5)
+
+    assert_equal_query(
+            dfs,
+            group_by(_.g) >> filter(_.x > _.x.mean(), _.x != _.x.max()),
+            data_frame(x = [4, 9], g = [1, 2])
+            )
+
 
 @backend_sql("TODO: pandas - implement arrange over group by")
 @backend_notimpl("sqlite")

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -48,6 +48,7 @@ def df3(backend):
     return backend.load_df(DF3)
 
 
+# Test different ways to specify on argument ----------------------------------
 
 @backend_sql("TODO: pandas")
 def test_join_diff_vars_keeps_left(backend, df1, df2_jj):
@@ -184,4 +185,16 @@ def test_basic_anti_join_on_multi(backend, df1, df2):
             anti_join(df1, df2, on = {"ii": "ii", "x": "y"}) >> collect(),
             DF1.iloc[2:,]
             )
+
+
+# Test that sql joins reset order by ------------------------------------------
+from siuba import arrange
+from pandas.testing import assert_frame_equal
+
+@backend_sql
+def test_inner_join_arrange(backend, df1, df2):
+    # NOTE: joins are free to scramble order in SQL. TODO: check dplyr
+    joined = inner_join(arrange(df1, _.ii), df2, on = "ii")
+
+    assert joined.order_by == tuple()
 


### PR DESCRIPTION
addresses #276, and a gnarly issue introduced recently, where multiple conditions in a filter produced multiple FROM clauses that didn't work, rather than a chain of subqueries (how siuba operates).

The filter issue was caused because it attempts to swap in the right table into a sql operation using sqlalchemy's ClauseAdapter. However, because the original select object was being mutated, I don't think sqlalchemy recognized the columns used prior to the mutation as coming from the "same" object. This meant it didn't swap them out for the aliased version of the select.

As a result, both the unaliased and aliased select statements were used:

```sql
SELECT anon_1.cyl, anon_1.mpg, anon_1.hp 
FROM 
    -- first clause w/ table alias
    (SELECT anon_2.cyl AS cyl, anon_2.mpg AS mpg, anon_2.hp AS hp, avg(anon_2.mpg) OVER () AS anon_3, avg(anon_2.hp) OVER () AS anon_4 
FROM (SELECT cars.cyl AS cyl, cars.mpg AS mpg, cars.hp AS hp 
FROM cars) AS anon_2) AS anon_1,
    -- second clause no table alias :/
    (SELECT anon_2.cyl AS cyl, anon_2.mpg AS mpg, anon_2.hp AS hp, avg(anon_2.mpg) OVER () AS anon_3, avg(anon_2.hp) OVER () AS anon_4 
FROM (SELECT cars.cyl AS cyl, cars.mpg AS mpg, cars.hp AS hp 
FROM cars) AS anon_2) 
WHERE anon_3 > 10 AND anon_1.anon_4 > 100
```

