### PR TITLE
feat: pandas arrange supports grouped, sql supports minus for desc

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -97,7 +97,7 @@ class Pipeable:
 pipe = Pipeable
 
 def _regroup(df):
-    # try to regroup, when user kept index (e.g. group_keys = True)
+    # try to regroup after an apply, when user kept index (e.g. group_keys = True)
     if len(df.index.names) > 1:
         # handle cases where...
         # 1. grouping with named indices (as_index = True)
@@ -706,7 +706,19 @@ def arrange(__data, *args):
 
 @arrange.register(DataFrameGroupBy)
 def _arrange(__data, *args):
-    raise NotImplementedError("TODO: arrange with grouped DataFrame")
+    for arg in args:
+        f, desc = _call_strip_ascending(arg)
+        if not simple_varname(f):
+            raise NotImplementedError(
+                    "Arrange over DataFrameGroupBy only supports simple "
+                    "column names, not expressions"
+                    )
+
+    df_sorted = arrange(__data.obj, *args)
+
+    group_cols = [ping.name for ping in __data.grouper.groupings]
+    return df_sorted.groupby(group_cols)
+
 
 
 

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -590,6 +590,7 @@ def _arrange(__data, *args):
     new_calls = []
     for ii, expr in enumerate(args):
         if callable(expr):
+
             res = __data.shape_call(
                     expr, window = False,
                     verb_name = "Arrange", arg_name = ii
@@ -615,9 +616,10 @@ def _create_order_by_clause(columns, *args):
             sort_cols.append(columns[arg])
         # an expression
         elif callable(arg):
-            #f, asc = _call_strip_ascending(arg)
-            #col_op = f(cols) if asc else f(cols).desc()
-            col_op = arg(columns)
+            # handle special case where -_.colname -> colname DESC
+            f, asc = _call_strip_ascending(arg)
+            col_op = f(columns) if asc else f(columns).desc()
+            #col_op = arg(columns)
             sort_cols.append(col_op)
         else:
             raise NotImplementedError("Must be string or callable")

--- a/siuba/tests/test_verb_arrange.py
+++ b/siuba/tests/test_verb_arrange.py
@@ -1,5 +1,5 @@
 from siuba.dply.verbs import simple_varname
-from siuba import _, filter, group_by, arrange, mutate
+from siuba import _, filter, group_by, arrange, mutate, ungroup
 from siuba.dply.vector import row_number, desc
 import pandas as pd
 
@@ -40,6 +40,31 @@ def test_arrange_desc(df, query, output):
     ])
 def test_arrange_with_expr(df, query, output):
     assert_equal_query(df, query, output)
+
+
+def test_arrange_grouped_trivial(df):
+    # note: only 1 level for z
+    assert_equal_query(
+            df,
+            group_by(_.z) >> arrange(_.x),
+            DATA.sort_values(['x'])
+            )
+
+@backend_notimpl("sqlite")
+def test_arrange_grouped(backend, df):
+    q = group_by(_.y) >> arrange(_.x)
+    assert_equal_query(
+            df,
+            q,
+            DATA.sort_values(['x'])
+            )
+
+    # arrange w/ mutate is the same, whether used before or after group_by
+    assert_equal_query(
+            df,
+            q >> mutate(res = row_number(_)),
+            mutate(DATA.sort_values(['x']).groupby('y'), res = row_number(_))
+            )
 
 
 # SQL -------------------------------------------------------------------------


### PR DESCRIPTION
Previously, sql queries like

```python
from siuba.data import cars_sql
from siuba import _, show_query, arrange

q = cars_sql >> arrange(-_.mpg) >> show_query()
```

```sql
SELECT cars.cyl, cars.mpg, cars.hp 
FROM cars ORDER BY -cars.mpg
```

Now it correctly uses DESC

```sql
SELECT cars.cyl, cars.mpg, cars.hp 
FROM cars ORDER BY cars.mpg DESC
```

(whether `-` should be used like this is still up for debate!)