### PR TITLE
fix: data_frame helper, latest pandas no broadcast single item list

### DIFF
--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -10,9 +10,13 @@ def data_frame(*args, _index = None, **kwargs):
     if len(args):
         raise NotImplementedError("all arguments to data_frame must be named")
 
+    all_scalars = all(not np.ndim(v) for v in kwargs.values())
+
+    if all_scalars:
+        fixed = {k: [v] for k,v in kwargs.items()}
+        return pd.DataFrame(fixed, index = _index)
     
-    fixed = {k: [v] if not np.ndim(v) else v for k,v in kwargs.items()}
-    return pd.DataFrame(fixed, index = _index)
+    return pd.DataFrame(kwargs, index = _index)
 
 BACKEND_CONFIG = {
         "postgresql": {


### PR DESCRIPTION
I think pandas v1 removed the ability to broadcast len 1 lists:

```
import pandas as pd

pd.DataFrame({'a': [1], 'b': [2,3]})   # error, unequal lens
```