### PR TITLE
fix: basic sqlalchemy 1.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           - name: "2020-mid dependencies"
             python-version: 3.8
             requirements: numpy~=1.19.1 pandas~=1.1.0 SQLAlchemy~=1.3.18 psycopg2~=2.8.5
+          - name: "2021-mid dependencies"
+            python-version: 3.8
+            requirements: numpy~=1.19.1 pandas~=1.1.0 SQLAlchemy~=1.4.13 psycopg2~=2.8.5
 
     # Service containers to run with `container-job`
     services:

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -56,13 +56,16 @@ import sqlalchemy
 RE_VERSION=r"(?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)"  
 SQLA_VERSION=tuple(map(int, re.match(RE_VERSION, sqlalchemy.__version__).groups()))
 
+def is_sqla_12():
+    return SQLA_VERSION[:-1] == (1, 2)
+
 def is_sqla_13():
     return SQLA_VERSION[:-1] == (1, 3)
 
 
 def _sql_select(columns, *args, **kwargs):
     from sqlalchemy import sql
-    if is_sqla_13():
+    if is_sqla_12() or is_sqla_13():
         # use old syntax, where columns are passed as a list
         return sql.select(columns, *args, **kwargs)
 
@@ -72,7 +75,7 @@ def _sql_select(columns, *args, **kwargs):
 def _sql_column_collection(data, columns):
     from sqlalchemy.sql.base import ColumnCollection, ImmutableColumnCollection
 
-    if is_sqla_13():
+    if is_sqla_12() or is_sqla_13():
         return ImmutableColumnCollection(data, columns)
 
     return ColumnCollection(list(data.items())).as_immutable()

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -70,11 +70,9 @@ def _sql_select(columns, *args, **kwargs):
 
 
 def _sql_column_collection(data, columns):
-    from sqlalchemy.sql import ColumnCollection
+    from sqlalchemy.sql.base import ColumnCollection, ImmutableColumnCollection
 
     if is_sqla_13():
-        cols = ColumnCollection(data, columns)
-    else:
-        cols = ColumnCollection(list(data.items()))
+        return ImmutableColumnCollection(data, columns)
 
-    return cols.as_immutable()
+    return ColumnCollection(list(data.items())).as_immutable()

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -79,3 +79,12 @@ def _sql_column_collection(data, columns):
         return ImmutableColumnCollection(data, columns)
 
     return ColumnCollection(list(data.items())).as_immutable()
+
+
+def _sql_add_columns(select, columns):
+    if is_sqla_12() or is_sqla_13():
+        for column in columns:
+            select = select.column(column)
+        return select
+
+    return select.add_columns(*columns)

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -47,3 +47,34 @@ class _FixedSqlDatabase(_pd_sql.SQLDatabase):
     def execute(self, *args, **kwargs):
         return self.connectable.execute(*args, **kwargs)
 
+
+# Backwards compatibility for sqlalchemy 1.3 ----------------------------------
+
+import re
+import sqlalchemy
+
+RE_VERSION=r"(?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)"  
+SQLA_VERSION=tuple(map(int, re.match(RE_VERSION, sqlalchemy.__version__).groups()))
+
+def is_sqla_13():
+    return SQLA_VERSION[:-1] == (1, 3)
+
+
+def _sql_select(columns, *args, **kwargs):
+    from sqlalchemy import sql
+    if is_sqla_13():
+        # use old syntax, where columns are passed as a list
+        return sql.select(columns, *args, **kwargs)
+
+    return sql.select(*columns, *args, **kwargs)
+
+
+def _sql_column_collection(data, columns):
+    from sqlalchemy.sql import ColumnCollection
+
+    if is_sqla_13():
+        cols = ColumnCollection(data, columns)
+    else:
+        cols = ColumnCollection(list(data.items()))
+
+    return cols.as_immutable()

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -545,7 +545,7 @@ def _mutate_select(sel, colname, func, labs, __data):
     function handles whether to add a column to the existing select statement,
     or to use it as a subquery.
     """
-    replace_col = colname in sel.columns
+    replace_col = colname in lift_inner_cols(sel)
     # Call objects let us check whether column expr used a derived column
     # e.g. SELECT a as b, b + 1 as c raises an error in SQL, so need subquery
     if not col_expr_requires_cte(func, sel, is_mutate = True):
@@ -1053,7 +1053,7 @@ def _distinct(__data, *args, _keep_all = False, **kwargs):
 
     # use all columns by default
     if not cols:
-        cols = list(inner_sel.columns.keys())
+        cols = lift_inner_cols(inner_sel).keys()
 
     if not len(inner_sel._order_by_clause):
         # select distinct has to include any columns in the order by clause,

--- a/siuba/tests/test_verb_summarize.py
+++ b/siuba/tests/test_verb_summarize.py
@@ -51,7 +51,7 @@ def test_summarize_after_mutate_cuml_win(backend, df_float):
 @backend_sql
 def test_summarize_keeps_group_vars(backend, gdf):
     q = gdf >> summarize(n = n(_))
-    assert list(q.last_op.c.keys()) == ["g", "n"]
+    assert list(q.last_op.alias().columns.keys()) == ["g", "n"]
 
 
 @pytest.mark.parametrize("query, output", [


### PR DESCRIPTION
addresses #321, #326. Note that sqlalchemy 1.4 is preparing for more API changes, so is issuing quite a few deprecation warnings. These shouldn't be an issue for now. I'm going to take another pass over to try and change all deprecated behaviors, then merge by EOW.

TODO:

- [x] : add sqlalchemy 1.4 to CI tests
- [x] : fix small piece with ColumnCollection breaking v1.3 tests
- [x] : try to quickly clean up methods deprecated in 1.4
- [x] : clean up deprecated `engine.execute` method