### PR TITLE
docs: fix broken example

### DIFF
--- a/docs/developer/sql-translators.ipynb
+++ b/docs/developer/sql-translators.ipynb
@@ -322,7 +322,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "col, windows = track_call_windows(\n",
+    "col, windows, cte = track_call_windows(\n",
     "    func_call3,\n",
     "    sel.columns,\n",
     "    group_by = ['x', 'y'],\n",


### PR DESCRIPTION
fixes an example in dev docs, where `track_call_windows`  became out of date.