### PR TITLE
[WIP] Query optimization for JOINs to not default to SELECT subqueries (for LazyTbl)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  pull_request:
   release:
     types: [published]
 

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -884,10 +884,14 @@ def _resolve_select_object(sel):
     if len(froms) == 1:
         from_obj = froms[0]
         sel_from = from_obj.select()
+
+        # sqlalchemy doesn't allow direct comparison of the column set as it is linked to the database
+        # but if the sets of column names match, we are sure to be selecting the same thing
         col_names_original = set([c.name for c in sel.columns])
         col_names_constructed = set([c.name for c in sel_from.columns])
         if col_names_original == col_names_constructed:
             # initial select is equivalent to just selecting everything from the from_object
+            # therefore the select itself can be omitted
             sel = from_obj
 
     return sel

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -876,7 +876,6 @@ def _relabeled_cols(columns, keys, suffix):
         cols.append(new_col)
     return cols
 
-
 @join.register(LazyTbl)
 def _join(left, right, on = None, *args, how = "inner", sql_on = None):
     _raise_if_args(args)
@@ -895,6 +894,7 @@ def _join(left, right, on = None, *args, how = "inner", sql_on = None):
 
     # handle arguments ----
     on  = _validate_join_arg_on(on, sql_on)
+    on  = _interpret_dotted_on_dicts(on)
     how = _validate_join_arg_how(how)
     
     # for equality join used to combine keys into single column
@@ -988,6 +988,14 @@ def _anti_join(left, right = None, on = None, *args, sql_on = None):
 def _raise_if_args(args):
     if len(args):
         raise NotImplemented("*args is reserved for future arguments (e.g. suffix)")
+
+def _interpret_dotted_on_dicts(on):
+    # interpret "on" dictionaries of the form:
+    # {table1.column: table2.column}
+    # and convert them to the format used throughout:
+    # {table1_column: table2_column}
+    # hacky, maybe the format with the dot should be enforced
+    return {k.replace(".", "_"): v.replace(".", "_") for k, v in on.items()}
 
 def _validate_join_arg_on(on, sql_on = None):
     # handle sql on case

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -893,6 +893,8 @@ def _resolve_select_object(sel):
             # initial select is equivalent to just selecting everything from the from_object
             # therefore the select itself can be omitted
             sel = from_obj
+        else:
+            sel = sel.alias()
 
     return sel
 

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -1012,7 +1012,8 @@ def _interpret_dotted_on_dicts(on):
     # and convert them to the format used throughout:
     # {table1_column: table2_column}
     # hacky, maybe the format with the dot should be enforced
-    return {k.replace(".", "_"): v.replace(".", "_") for k, v in on.items()}
+    return (on if callable(on)
+            else {k.replace(".", "_"): v.replace(".", "_") for k, v in on.items()})
 
 def _validate_join_arg_on(on, sql_on = None):
     # handle sql on case

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -1018,7 +1018,6 @@ def _validate_join_arg_how(how):
     return how
 
 def _create_join_conds(left_sel, right_sel, on):
-    print(left_sel, right_sel)
     left_cols  = left_sel.columns  #lift_inner_cols(left_sel)
     right_cols = right_sel.columns #lift_inner_cols(right_sel)
 
@@ -1028,13 +1027,7 @@ def _create_join_conds(left_sel, right_sel, on):
     else:
         # dict-like of form {left: right}
         conds = []
-        print(on)
-        print(left_cols.keys())
-        print(right_cols.keys())
-        print("-----")
         for l, r in on.items():
-            print(l,r)
-            print("..")
             col_expr = left_cols[l] == right_cols[r]
             conds.append(col_expr)
             

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -893,10 +893,8 @@ def _resolve_select_object(sel):
             # initial select is equivalent to just selecting everything from the from_object
             # therefore the select itself can be omitted
             sel = from_obj
-        else:
-            sel = sel.alias()
 
-    return sel
+    return sel.alias()
 
 @join.register(LazyTbl)
 def _join(left, right, on = None, *args, how = "inner", sql_on = None):

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -882,8 +882,16 @@ def _join(left, right, on = None, *args, how = "inner", sql_on = None):
     _raise_if_args(args)
 
     # Needs to be on the table, not the select
-    left_sel = left.last_op.alias()
-    right_sel = right.last_op.alias()
+    left_sel = left.last_op
+    right_sel = right.last_op
+
+    left_froms = left_sel.froms
+    right_froms = right_sel.froms
+
+    if len(left_froms) == 1:
+        left_sel = left_froms[0]
+    if len(right_froms) == 1:
+        right_sel = right_froms[0]
 
     # handle arguments ----
     on  = _validate_join_arg_on(on, sql_on)
@@ -1010,6 +1018,7 @@ def _validate_join_arg_how(how):
     return how
 
 def _create_join_conds(left_sel, right_sel, on):
+    print(left_sel, right_sel)
     left_cols  = left_sel.columns  #lift_inner_cols(left_sel)
     right_cols = right_sel.columns #lift_inner_cols(right_sel)
 
@@ -1019,7 +1028,13 @@ def _create_join_conds(left_sel, right_sel, on):
     else:
         # dict-like of form {left: right}
         conds = []
+        print(on)
+        print(left_cols.keys())
+        print(right_cols.keys())
+        print("-----")
         for l, r in on.items():
+            print(l,r)
+            print("..")
             col_expr = left_cols[l] == right_cols[r]
             conds.append(col_expr)
             


### PR DESCRIPTION
See [Issue 346](https://github.com/machow/siuba/issues/346). 

The current implementation of JOIN uses SELECT subqueries for the joined instances. The idea here is to abstain from doing that. 

A few issues that will need to be resolved:

1. What to do with aliasing, so we still want to keep an alias of the tables by default?
2. A bigger one - now the `on` argument becomes more ambiguous since when we have consecutive joins, we would need to specify on which table's column we're joining on. The current implementation seems to be fine with accepting a dictionary `{"<table1>_<column1>" : "<table2>_<column2>"}`. However this could be an annoying/bothersome/confusing notation in some cases (especially if tables/columns have underscores in their names)
3. Would a standard like this need to be enforced in other places as well/an option to toggle between the current and this way could be added.