### PR TITLE
fix(install): correclty read utf-8 in readme on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('siuba/__init__.py', 'rb') as f:
     VERSION = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
 
-with open('README.md') as f:
+with open('README.md', encoding="utf-8") as f:
     README = f.read()
 
 # setup -----------------------------------------------------------------------


### PR DESCRIPTION
Addresses #336, #369

TODO:

- [x] : dust off and test on my windows workstation ;)

edit: replicated install breaking on python 3.10.1 for Windows 10. `pip install git+https://github.com/machow/siuba.git@fix-install-encoding` worked, so going to merge!