### PR TITLE
Fix semi_join inferring on arg

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -1117,7 +1117,7 @@ def semi_join(left, right = None, on = None):
 
         on_cols = list(set(left.columns).intersection(set(right.columns)))
         if not len(on_cols):
-            raise Exception("No joining column specified, and no shared column names")
+            raise Exception("No join column specified, and no shared column names")
 
         warnings.warn("Detected shared columns: %s" % on_cols)
     elif isinstance(on, str):

--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -1110,9 +1110,16 @@ def semi_join(left, right = None, on = None):
         on_cols, right_on = map(list, zip(*on.items()))
         right = right[right_on].rename(dict(zip(right_on, on_cols)))
     elif on is None:
-        on_cols = set(left.columns).intersection(set(right.columns))
+        warnings.warn(
+            "No on column passed to join. "
+            "Inferring join columns instead using shared column names."
+        )
+
+        on_cols = list(set(left.columns).intersection(set(right.columns)))
         if not len(on_cols):
             raise Exception("No joining column specified, and no shared column names")
+
+        warnings.warn("Detected shared columns: %s" % on_cols)
     elif isinstance(on, str):
         on_cols = [on]
     else:

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -1005,7 +1005,7 @@ def _validate_join_arg_on(on, sql_on = None, lhs = None, rhs = None):
 
             if not on_cols:
                 raise ValueError(
-                    "No on columns specified, or shared column names in join."
+                    "No join column specified, or shared column names in join."
                 )
 
             # trivial dict mapping shared names to themselves

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -169,6 +169,19 @@ def test_semi_join_no_cross(backend, df1, df2):
             DF1.iloc[:1,]
             )
 
+def test_semi_join_no_on_arg(backend, df1):
+    df_ii = backend.load_df(data_frame(ii = [1,1]))
+
+    with pytest.warns(UserWarning) as record:
+        assert_equal_query(
+                df1,
+                semi_join(_, df_ii),
+                DF1.iloc[:1,]
+                )
+
+    assert "No on column passed to join." in record[0].message.args[0]
+    assert "['ii']" in record[1].message.args[0]
+
 
 def test_basic_anti_join_on_map(backend, df1, df2):
     assert_frame_sort_equal(

--- a/siuba/tests/test_verb_join.py
+++ b/siuba/tests/test_verb_join.py
@@ -182,6 +182,14 @@ def test_semi_join_no_on_arg(backend, df1):
     assert "No on column passed to join." in record[0].message.args[0]
     assert "['ii']" in record[1].message.args[0]
 
+def test_semi_join_no_on_arg_fail(backend, df1):
+    df_ii = backend.load_df(data_frame(ZZ = [1,1]))
+
+    with pytest.raises(Exception) as excinfo:
+        collect(semi_join(df1, df_ii))
+    
+    assert "No join column specified" in str(excinfo.value) 
+
 
 def test_basic_anti_join_on_map(backend, df1, df2):
     assert_frame_sort_equal(


### PR DESCRIPTION
addresses #351 

* fixes pandas semi_join erroneously using a set rather than list when inferring on cols.
* sql semi_join now implements inferring on cols 
* tests of the behavior