### PR TITLE
feat(sql): implement basic duckdb dialect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python -m pip install .
           # step to test duckdb
           # TODO: move these requirements into the test matrix
-          pip install git+https://github.com/Mause/duckdb_engine.git
+          pip install git+https://github.com/machow/duckdb_engine.git@feat-name-dialect
         env:
           REQUIREMENTS: ${{ matrix.requirements }}
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
           python -m pip install $REQUIREMENTS
           python -m pip install -r requirements-test.txt
           python -m pip install .
+          # step to test duckdb
+          # TODO: move these requirements into the test matrix
+          pip install git+https://github.com/Mause/duckdb_engine.git
         env:
           REQUIREMENTS: ${{ matrix.requirements }}
       - name: Test with pytest
@@ -61,19 +64,6 @@ jobs:
         env:
           SB_TEST_PGPORT: 5432
           PYTEST_FLAGS: ${{ matrix.pytest_flags }}
-
-      # optional step for running bigquery tests ----
-      - name: Set up Cloud SDK
-        if: ${{(contains(github.ref, 'bigquery') || contains(github.ref, 'refs/tags')) && matrix.latest}}
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: siuba-tests
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-      - name: Test bigquery
-        if: ${{(contains(github.ref, 'bigquery') || contains(github.ref, 'refs/tags')) && matrix.latest}}
-        run: |
-          pip install git+https://github.com/googleapis/python-bigquery-sqlalchemy.git pandas-gbq==0.15.0
 
   test-bigquery:
     name: "Test BigQuery"

--- a/siuba/ops/support/base.py
+++ b/siuba/ops/support/base.py
@@ -8,7 +8,7 @@ from siuba.ops import ALL_OPS
 from siuba.siu import FunctionLookupBound
 from siuba.sql.utils import get_dialect_translator
 
-SQL_BACKENDS = ["postgresql", "redshift", "sqlite", "mysql", "bigquery"]
+SQL_BACKENDS = ["postgresql", "redshift", "sqlite", "mysql", "bigquery", "duckdb"]
 ALL_BACKENDS = SQL_BACKENDS + ["pandas"]
 
 methods = pd.DataFrame(

--- a/siuba/sql/dialects/base.py
+++ b/siuba/sql/dialects/base.py
@@ -87,7 +87,7 @@ def sql_is_first_of(name, reference):
     return lambda col: fn.date_trunc(name, col) == fn.date_trunc(reference, col)
 
 def sql_func_last_day_in_period(col, period):
-    return fn.date_trunc(period, col) + sql.text("INTERVAL 1 %s - INTERVAL 1 day" % period)
+    return fn.date_trunc(period, col) + sql.text("INTERVAL '1 %s' - INTERVAL '1 day'" % period)
 
 def sql_func_days_in_month(col):
     return fn.extract('day', sql_func_last_day_in_period(col, 'month'))

--- a/siuba/sql/dialects/base.py
+++ b/siuba/sql/dialects/base.py
@@ -80,13 +80,14 @@ def sql_func_extract_dow_monday(col):
     # make monday = 0 rather than sunday
     monday0 = sql.cast(sql.func.extract('dow', col) + 6, sa_types.Integer) % 7
     # cast to numeric, since that's what extract('dow') returns
-    return sql.cast(monday0, sa_types.Numeric)
+    #return sql.cast(monday0, sa_types.Numeric)
+    return monday0
 
 def sql_is_first_of(name, reference):
     return lambda col: fn.date_trunc(name, col) == fn.date_trunc(reference, col)
 
 def sql_func_last_day_in_period(col, period):
-    return fn.date_trunc(period, col) + sql.text("interval '1 %s - 1 day'" % period)
+    return fn.date_trunc(period, col) + sql.text("INTERVAL 1 %s - INTERVAL 1 day" % period)
 
 def sql_func_days_in_month(col):
     return fn.extract('day', sql_func_last_day_in_period(col, 'month'))
@@ -152,6 +153,56 @@ def req_bool(f):
 # =============================================================================
 # Base translation mappings
 # =============================================================================
+
+scalar_dt_methods = {
+      #"dt.ceil"             :
+      #"dt.date"             :
+      "dt.day"              : sql_extract("day"),
+      #"dt.day_name"         :
+      "dt.dayofweek"        : sql_func_extract_dow_monday,
+      "dt.dayofyear"        : sql_extract("doy"),
+      #"dt.days"             :
+      "dt.days_in_month"    : sql_func_days_in_month,
+      "dt.daysinmonth"      : sql_func_days_in_month,
+      #"dt.floor"            :
+      "dt.hour"             : sql_extract("hour"),
+      #"dt.is_leap_year"     :
+      "dt.is_month_end"     : sql_is_last_day_of("month"),
+      "dt.is_month_start"   : sql_is_first_of("day", "month"),
+      #"dt.is_quarter_end"   :
+      "dt.is_quarter_start" : sql_is_first_of("day", "quarter"),
+      "dt.is_year_end"      : sql_is_last_day_of("year"),
+      "dt.is_year_start"    : sql_is_first_of("day", "year"),
+      #"dt.microsecond"      :
+      #"dt.microseconds"     :
+      "dt.minute"           : sql_extract("minute"),
+      "dt.month"            : sql_extract("month"),
+      #"dt.month_name"       :
+      #"dt.nanosecond"       :
+      #"dt.nanoseconds"      :
+      #"dt.normalize"        :
+      "dt.quarter"          : sql_extract("quarter"),
+      #"dt.qyear"            :
+      #dt.round            =
+      "dt.second"           : sql_extract("second"),
+      #"dt.seconds"          :
+      #"dt.strftime"         :
+      #"dt.time"             :
+      #"dt.timetz"           :
+      #"dt.to_period"        :
+      #"dt.to_pydatetime"    :
+      #"dt.to_pytimedelta"   :
+      #"dt.to_timestamp"     :
+      #"dt.total_seconds"    :
+      #dt.tz_convert       =
+      #dt.tz_localize      =
+      "dt.week"             : sql_extract("week"),
+      "dt.weekday"          : sql_func_extract_dow_monday,
+      "dt.weekofyear"       : sql_extract("week"),
+      "dt.year"             : sql_extract("year"),
+      #"dt.freq" : 
+      #"dt.tz"   :
+}
 
 base_scalar = dict(
     # infix ----
@@ -274,57 +325,7 @@ base_scalar = dict(
 
 
     # datetime ----
-
-
-    **{
-      #"dt.ceil"             :
-      #"dt.date"             :
-      "dt.day"              : sql_extract("day"),
-      #"dt.day_name"         :
-      "dt.dayofweek"        : sql_func_extract_dow_monday,
-      "dt.dayofyear"        : sql_extract("doy"),
-      #"dt.days"             :
-      "dt.days_in_month"    : sql_func_days_in_month,
-      "dt.daysinmonth"      : sql_func_days_in_month,
-      #"dt.floor"            :
-      "dt.hour"             : sql_extract("hour"),
-      #"dt.is_leap_year"     :
-      "dt.is_month_end"     : sql_is_last_day_of("month"),
-      "dt.is_month_start"   : sql_is_first_of("day", "month"),
-      #"dt.is_quarter_end"   :
-      "dt.is_quarter_start" : sql_is_first_of("day", "quarter"),
-      "dt.is_year_end"      : sql_is_last_day_of("year"),
-      "dt.is_year_start"    : sql_is_first_of("day", "year"),
-      #"dt.microsecond"      :
-      #"dt.microseconds"     :
-      "dt.minute"           : sql_extract("minute"),
-      "dt.month"            : sql_extract("month"),
-      #"dt.month_name"       :
-      #"dt.nanosecond"       :
-      #"dt.nanoseconds"      :
-      #"dt.normalize"        :
-      "dt.quarter"          : sql_extract("quarter"),
-      #"dt.qyear"            :
-      #dt.round            =
-      "dt.second"           : sql_extract("second"),
-      #"dt.seconds"          :
-      #"dt.strftime"         :
-      #"dt.time"             :
-      #"dt.timetz"           :
-      #"dt.to_period"        :
-      #"dt.to_pydatetime"    :
-      #"dt.to_pytimedelta"   :
-      #"dt.to_timestamp"     :
-      #"dt.total_seconds"    :
-      #dt.tz_convert       =
-      #dt.tz_localize      =
-      "dt.week"             : sql_extract("week"),
-      "dt.weekday"          : sql_func_extract_dow_monday,
-      "dt.weekofyear"       : sql_extract("week"),
-      "dt.year"             : sql_extract("year"),
-      #"dt.freq" : 
-      #"dt.tz"   :
-      },
+    **scalar_dt_methods,
 
 
     # datetime methods not on accessor ----

--- a/siuba/sql/dialects/duckdb.py
+++ b/siuba/sql/dialects/duckdb.py
@@ -1,0 +1,72 @@
+from sqlalchemy.sql import func as fn
+from sqlalchemy import sql
+
+from ..translate import (
+    # data types
+    SqlColumn, SqlColumnAgg,
+    # transformations
+    wrap_annotate,
+    sql_agg,
+    win_agg,
+    win_cumul,
+    sql_not_impl,
+    # wiring up translator
+    extend_base,
+    SqlTranslator
+)
+
+from .postgresql import (
+    PostgresqlColumn,
+    PostgresqlColumnAgg,
+    scalar as pg_scalar,
+    aggregate as pg_agg,
+    window as pg_win
+)
+
+from .base import scalar_dt_methods
+from .base import sql_func_rank
+
+class DuckdbColumn(PostgresqlColumn): pass
+class DuckdbColumnAgg(PostgresqlColumnAgg, DuckdbColumn): pass
+
+
+def sql_func_last_day_in_period(col, period):
+    return fn.date_trunc(period, col) + sql.text("INTERVAL '1 %s - INTERVAL 1 day'" % period)
+
+def sql_func_days_in_month(col):
+    return fn.extract('day', sql_func_last_day_in_period(col, 'month'))
+
+def sql_is_last_day_of(period):
+    def f(col):
+        last_day = sql_func_last_day_in_period(col, period)
+        return fn.date_trunc('day', col) == last_day
+
+    return f
+
+scalar = extend_base(
+        pg_scalar,
+        **{
+            "str.contains": lambda col, re: fn.regexp_matches(col, re),
+            "str.title": sql_not_impl(),
+        },
+        **scalar_dt_methods,
+        )
+
+
+aggregate = extend_base(
+        pg_agg,
+        sum = sql_agg("sum"),
+        )
+
+window = extend_base(
+        pg_win,
+        cumsum = win_cumul("sum"),
+        sum = win_agg("sum"),
+        rank = wrap_annotate(sql_func_rank, result_type = "int"),
+        )
+
+
+translator = SqlTranslator.from_mappings(
+        scalar, window, aggregate,
+        DuckdbColumn, DuckdbColumnAgg
+        )

--- a/siuba/sql/dialects/postgresql.py
+++ b/siuba/sql/dialects/postgresql.py
@@ -90,7 +90,7 @@ scalar = extend_base(
         **returns_float(base_scalar, [
              "dt.day", "dt.dayofyear", "dt.days_in_month",
              "dt.daysinmonth", "dt.hour", "dt.minute", "dt.month",
-             "dt.quarter", "dt.second", "dt.week", "dt.weekday",
+             "dt.quarter", "dt.second", "dt.week",
              "dt.weekofyear", "dt.year"
              ]),
         )

--- a/siuba/sql/dialects/postgresql.py
+++ b/siuba/sql/dialects/postgresql.py
@@ -88,7 +88,7 @@ scalar = extend_base(
             "str.contains": sql_func_contains,
         },
         **returns_float(base_scalar, [
-             "dt.day", "dt.dayofweek", "dt.dayofyear", "dt.days_in_month",
+             "dt.day", "dt.dayofyear", "dt.days_in_month",
              "dt.daysinmonth", "dt.hour", "dt.minute", "dt.month",
              "dt.quarter", "dt.second", "dt.week", "dt.weekday",
              "dt.weekofyear", "dt.year"

--- a/siuba/sql/dply/vector.py
+++ b/siuba/sql/dply/vector.py
@@ -12,6 +12,7 @@ from ..translate import (
 from ..dialects.sqlite import SqliteColumn
 from ..dialects.mysql import MysqlColumn
 from ..dialects.bigquery import BigqueryColumn
+from ..dialects.duckdb import DuckdbColumn
 
 from siuba.dply.vector import (
         #cumall, cumany, cummean,
@@ -98,6 +99,9 @@ min_rank    .register(MysqlColumn, _sql_rank("rank", partition = True))
 # see: https://stackoverflow.com/q/1498648/1144523
 dense_rank  .register(BigqueryColumn, _sql_rank("dense_rank", nulls_last = True))
 percent_rank.register(BigqueryColumn, _sql_rank("percent_rank", nulls_last = True))
+
+# duckdb
+dense_rank  .register(DuckdbColumn, _sql_rank("dense_rank", nulls_last = True))
 
 
 

--- a/siuba/tests/conftest.py
+++ b/siuba/tests/conftest.py
@@ -10,6 +10,7 @@ params_backend = [
     pytest.param(lambda: SqlBackend("postgresql"), id = "postgresql", marks=pytest.mark.postgresql),
     pytest.param(lambda: SqlBackend("mysql"), id = "mysql", marks=pytest.mark.mysql),
     pytest.param(lambda: SqlBackend("sqlite"), id = "sqlite", marks=pytest.mark.sqlite),
+    pytest.param(lambda: SqlBackend("duckdb"), id = "duckdb", marks=pytest.mark.duckdb),
     pytest.param(lambda: BigqueryBackend("bigquery"), id = "bigquery", marks=pytest.mark.bigquery),
     pytest.param(lambda: PandasBackend("pandas"), id = "pandas", marks=pytest.mark.pandas)
     ]

--- a/siuba/tests/test_sql_misc.py
+++ b/siuba/tests/test_sql_misc.py
@@ -35,7 +35,13 @@ def test_raw_sql_mutate_grouped(backend, df):
 def test_raw_sql_mutate_refer_previous_raise_dberror(backend, df):
     # Note: unlikely will be able to support this case. Normally we analyze
     # the expression to know whether we need to create a subquery.
-    with pytest.raises(sqlalchemy.exc.DatabaseError):
+    if backend.name == "duckdb":
+        # duckdb dialect re-raises the engines exception, which is RuntimeError
+        exc = RuntimeError
+    else:
+        exc = sqlalchemy.exc.DatabaseError
+
+    with pytest.raises(exc):
         assert_equal_query(
                 df,
                 group_by("x") >> mutate(z1 = sql_raw("y + 1"), z2 = sql_raw("z1 + 1")),

--- a/siuba/tests/test_verb_count.py
+++ b/siuba/tests/test_verb_count.py
@@ -49,7 +49,7 @@ def test_count_with_kwarg_expression(df):
             pd.DataFrame({"y": [0], "n": [4]})
             )
 
-@backend_notimpl("sqlite", "postgresql", "mysql", "bigquery")     # see (#104)
+@backend_notimpl("sql")     # see (#104)
 def test_count_wt(backend, df):
     assert_equal_query(
             df,
@@ -65,7 +65,7 @@ def test_count_no_groups(df):
             pd.DataFrame({'n': [4]})
             )
 
-@backend_notimpl("sqlite", "postgresql", "mysql", "bigquery")   # see (#104)
+@backend_notimpl("sql")   # see (#104)
 def test_count_no_groups_wt(backend, df):
     assert_equal_query(
             df,


### PR DESCRIPTION
Implements a duckdb sql dialect, that inherits from the postgres one. It supports the same range of methods (e.g. including `str.contains`), with the exception of `str.title`.

There are 4 failing tests, due to an issue of the duckdb sql alchemy -> pandas process, that seems to go as follows:

* when a verb has a literal value (e.g. mutate(x = 1))
* the resulting pandas column is "object" type
* this seems related to the use of sqlalchemy literals in queries

Below is short code to replicate the problem:

```python
import pandas as pd
from sqlalchemy import sql, create_engine

engine = create_engine("duckdb:///:memory:")

res_expr = pd.read_sql(
    sql.select(sql.literal(1).label('x')),  engine
)

res_str = pd.read_sql(
    """SELECT 1 AS x""",
    engine
)

res_expr.x.dtype     # object :/
res_str.x.dtype      # int
```