### PR TITLE
fix(ci): do not duplicate runs for all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
+    branches: ['main', 'dev-*']
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
#389 

* Removes github actions running twice when a branch from this repo is part of a PR
* still runs actions on PRs from forks