### PR TITLE
feat: support sqlite window functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,10 @@ jobs:
           export_default_credentials: true
       - name: Test with pytest
         run: |
-          pytest siuba -m bigquery --workers auto --tests-per-worker 2
+          # tests are mostly waiting on http requests to bigquery api
+          # note that test backends can cache data, so more processes
+          # is not always faster
+          pytest siuba -m bigquery --workers 2 --tests-per-worker 20
         env:
           SB_TEST_BQDATABASE: "ci_github"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-test.txt
           python -m pip install pytest-parallel
-          python -m pip install git+https://github.com/machow/pybigquery.git pandas-gbq==0.15.0
+          python -m pip install sqlalchemy-bigquery==1.3.0 pandas-gbq==0.15.0
           python -m pip install .
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
         env:
           SB_TEST_PGPORT: 5432
           PYTEST_FLAGS: ${{ matrix.pytest_flags }}
-          SB_TEST_SNOWFLAKEPASSWORD: ${{ secrets.SB_TEST_SNOWFLAKEPASSWORD }}
-          SB_TEST_SNOWFLAKEHOST: ${{ secrets.SB_TEST_SNOWFLAKEHOST }}
 
       # optional step for running bigquery tests ----
       - name: Set up Cloud SDK
@@ -78,13 +76,13 @@ jobs:
   test-bigquery:
     name: "Test BigQuery"
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'bigquery') || contains(github.ref, 'refs/tags')
+    if: contains(github.ref, 'bigquery') || ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -104,6 +102,29 @@ jobs:
         env:
           SB_TEST_BQDATABASE: "ci_github"
 
+  test-snowflake:
+    name: "Test snowflake"
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'snowflake') || ${{ !github.event.pull_request.draft }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-test.txt
+          python -m pip install snowflake-sqlalchemy==1.3.3
+          python -m pip install .
+      - name: Test with pytest
+        run: |
+          pytest siuba -m snowflake
+        env:
+          SB_TEST_SNOWFLAKEPASSWORD: ${{ secrets.SB_TEST_SNOWFLAKEPASSWORD }}
+          SB_TEST_SNOWFLAKEHOST: ${{ secrets.SB_TEST_SNOWFLAKEHOST }}
 
   build-docs:
     name: "Build Documentation"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-test.txt
+          python -m pip install pytest-parallel
           python -m pip install snowflake-sqlalchemy==1.3.3
           python -m pip install .
       - name: Test with pytest
         run: |
-          pytest siuba -m snowflake
+          pytest siuba -m snowflake --workers 2 --tests-per-worker 20
         env:
           SB_TEST_SNOWFLAKEPASSWORD: ${{ secrets.SB_TEST_SNOWFLAKEPASSWORD }}
           SB_TEST_SNOWFLAKEHOST: ${{ secrets.SB_TEST_SNOWFLAKEHOST }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install $REQUIREMENTS
           python -m pip install -r requirements-test.txt
-          python -m pip install snowflake-sqlalchemy==1.3.3
           python -m pip install .
         env:
           REQUIREMENTS: ${{ matrix.requirements }}
@@ -76,7 +75,7 @@ jobs:
   test-bigquery:
     name: "Test BigQuery"
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'bigquery') || ${{ !github.event.pull_request.draft }}
+    if: ${{ contains('bigquery', github.ref) || !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 
@@ -88,6 +87,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-test.txt
+          python -m pip install pytest-parallel
           python -m pip install git+https://github.com/machow/pybigquery.git pandas-gbq==0.15.0
           python -m pip install .
       - name: Set up Cloud SDK
@@ -98,14 +98,14 @@ jobs:
           export_default_credentials: true
       - name: Test with pytest
         run: |
-          pytest siuba -m bigquery
+          pytest siuba -m bigquery --workers auto --tests-per-worker 2
         env:
           SB_TEST_BQDATABASE: "ci_github"
 
   test-snowflake:
     name: "Test snowflake"
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'snowflake') || ${{ !github.event.pull_request.draft }}
+    if: ${{ contains('snowflake', github.ref) || !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -206,7 +206,7 @@ jobs:
     name: "Deploy to PyPI"
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    needs: [checks, test-bigquery]
+    needs: [checks, test-bigquery, test-snowflake]
     steps:
       - uses: actions/checkout@v2
       - name: "Set up Python 3.8"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 # since bigquery takes a long time to execute,
 # the tests are disabled by default.
-addopts = --doctest-modules -m 'not bigquery'
+addopts = --doctest-modules -m 'not bigquery and not snowflake'
 markers =
     skip_backend

--- a/siuba/sql/dialects/sqlite.py
+++ b/siuba/sql/dialects/sqlite.py
@@ -1,13 +1,19 @@
 # sqlvariant, allow defining 3 namespaces to override defaults
 from ..translate import (
         SqlColumn, SqlColumnAgg, extend_base,
-        SqlTranslator
+        SqlTranslator,
+        sql_not_impl,
+        annotate,
+        wrap_annotate
         )
 
 from .base import base_nowin
+#from .postgresql import PostgresqlColumn as SqlColumn, PostgresqlColumnAgg as SqlColumnAgg
+from . import _dt_generics as _dt
 
 import sqlalchemy.sql.sqltypes as sa_types
 from sqlalchemy import sql
+from sqlalchemy.sql import func as fn
 
 # Custom dispatching in call trees ============================================
 
@@ -16,18 +22,102 @@ from sqlalchemy import sql
 class SqliteColumn(SqlColumn): pass
 class SqliteColumnAgg(SqlColumnAgg, SqliteColumn): pass
 
-scalar = extend_base(
-        SqliteColumn,
-        )
+# Note this is taken from the postgres dialect, but it seems that there are 2 key points
+# compared to postgresql, which always returns a float
+# * sqlite date parts are returned as floats
+# * sqlite time parts are returned as integers
+def returns_float(func_names):
+    # TODO: MC-NOTE - shift all translations to directly register
+    # TODO: MC-NOTE - make an AliasAnnotated class or something, that signals
+    #                 it is using another method, but w/ an updated annotation.
+    from siuba.ops import ALL_OPS
+    
+    for name in func_names:
+        generic = ALL_OPS[name]
+        f_concrete = generic.dispatch(SqlColumn)
+        f_annotated = wrap_annotate(f_concrete, result_type="float")
+        generic.register(SqliteColumn, f_annotated)
 
-aggregate = extend_base(
-        SqliteColumnAgg,
-        )
+# detect first and last date (similar to the mysql dialect) ---
+@annotate(return_type="float")
+def sql_extract(name):
+    if name == "quarter":
+        # division in sqlite automatically rounds down
+        # so for jan, 1 + 2 = 3, and 3 / 1 is Q1
+        return lambda _, col: (fn.strftime("%m", col) + 2) / 3
+    return lambda _, col: fn.extract(name, col)
 
-window = extend_base(
+
+@_dt.sql_is_last_day_of.register
+def _sql_is_last_day_of(codata: SqliteColumn, col, period):
+    valid_periods = {"month",  "year"}
+    if period not in valid_periods:
+        raise ValueError(f"Period must be one of {valid_periods}")
+
+    incr = f"+1 {period}"
+
+    target_date = fn.date(col, f'start of {period}', incr, "-1 day")
+    return col == target_date
+
+@_dt.sql_is_first_day_of.register
+def _sql_is_first_day_of(codata: SqliteColumn, col, period):
+    valid_periods = {"month",  "year"}
+    if period not in valid_periods:
+        raise ValueError(f"Period must be one of {valid_periods}")
+
+    target_date = fn.date(col, f'start of {period}')
+    return fn.date(col) == target_date
+
+
+def sql_days_in_month(_, col):
+    date_last_day = fn.date(col, 'start of month', '+1 month', '-1 day')
+    return fn.strftime("%d", date_last_day).cast(sa_types.Integer())
+
+    
+@annotate(result_type = "float")
+def sql_round(_, col, n):
+    return sql.func.round(col, n)
+    
+def sql_func_truediv(_, x, y):
+    return sql.cast(x, sa_types.Float()) / y
+
+extend_base(
         SqliteColumn,
-        **base_nowin
+        div = sql_func_truediv,
+        divide = sql_func_truediv,
+        rdiv = lambda _, x,y: sql_func_truediv(_, y, x),
+
+        __truediv__ = sql_func_truediv,
+        truediv = sql_func_truediv,
+        __rtruediv__ = lambda _, x, y: sql_func_truediv(_, y, x),
+
+        round = sql_round,
+        __round__ = sql_round,
+        **{
+            "dt.quarter": sql_extract("quarter"),
+            "dt.is_quarter_start": sql_not_impl("TODO"),
+            "dt.is_quarter_end": sql_not_impl("TODO"),
+            "dt.days_in_month": sql_days_in_month,
+            "dt.daysinmonth": sql_days_in_month,
+
+        }
+)
+
+returns_float([
+    "dt.dayofweek", 
+    "dt.weekday",
+])
+
+
+extend_base(
+        SqliteColumn,
         # TODO: should check sqlite version, since < 3.25 can't use windows
+        quantile = sql_not_impl("sqlite does not support ordered set aggregates"),
+        )
+
+extend_base(
+        SqliteColumnAgg,
+        quantile = sql_not_impl("sqlite does not support ordered set aggregates"),
         )
 
 

--- a/siuba/sql/dply/vector.py
+++ b/siuba/sql/dply/vector.py
@@ -86,8 +86,8 @@ min_rank    .register(SqlColumn, _sql_rank("rank", partition = True))
 
 dense_rank  .register(SqliteColumn, _sql_rank("dense_rank", nulls_last=True))
 percent_rank.register(SqliteColumn, _sql_rank("percent_rank", nulls_last=True))
-cume_dist   .register(SqliteColumn, _sql_rank("cume_dist", nulls_last=True))
-min_rank    .register(SqliteColumn, _sql_rank("min_rank", nulls_last=True))
+cume_dist   .register(SqliteColumn, _sql_rank("cume_dist", partition = True))
+min_rank    .register(SqliteColumn, _sql_rank("rank", nulls_last=True))
 
 # partition everything, since MySQL puts NULLs first
 # see: https://stackoverflow.com/q/1498648/1144523
@@ -201,7 +201,6 @@ def _n_sql_agg(codata: SqlColumnAgg, x) -> ClauseElement:
     return sql.func.count()
 
 
-n.register(SqliteColumn, win_absent("N"))
 
 # n_distinct ------------------------------------------------------------------
 

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -243,7 +243,7 @@ def copy_to_sql(df, name, engine):
         df.to_gbq(qual_name, project_id, if_exists="replace") 
 
     else:
-        df.to_sql(name, engine, index = False, if_exists = "replace")
+        df.to_sql(name, engine, index = False, if_exists = "replace", method="multi")
 
     # manually create table, so we can be explicit about boolean columns.
     # this is necessary because MySQL reflection reports them as TinyInts,

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -231,7 +231,6 @@ def test_pandas_grouped_frame_fast_not_implemented(notimpl_entry):
 
 
 #@backend_pandas
-#@pytest.mark.skip_backend('sqlite')
 def test_frame_mutate(skip_backend, backend, entry):
     do_test_missing_implementation(entry, backend)
     skip_no_mutate(entry, backend)
@@ -296,7 +295,6 @@ def test_pandas_grouped_frame_fast_mutate(entry):
     assert_frame_equal(res_obj, dst.obj)
 
 
-@pytest.mark.skip_backend('sqlite')
 def test_frame_summarize(skip_backend, backend, agg_entry):
     entry = agg_entry
 

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -231,7 +231,7 @@ def test_pandas_grouped_frame_fast_not_implemented(notimpl_entry):
 
 
 #@backend_pandas
-@pytest.mark.skip_backend('sqlite')
+#@pytest.mark.skip_backend('sqlite')
 def test_frame_mutate(skip_backend, backend, entry):
     do_test_missing_implementation(entry, backend)
     skip_no_mutate(entry, backend)

--- a/siuba/tests/test_dply_vector.py
+++ b/siuba/tests/test_dply_vector.py
@@ -73,9 +73,6 @@ def simple_data(request):
 
 @pytest.mark.parametrize('func', OMNIBUS_VECTOR_FUNCS)
 def test_mutate_vector(backend, func, simple_data):
-    if backend.name == 'sqlite':
-        pytest.skip()
-
     df = backend.load_cached_df(simple_data)
     
     assert_equal_query(
@@ -96,9 +93,6 @@ def test_mutate_vector(backend, func, simple_data):
 
 @pytest.mark.parametrize('func', VECTOR_AGG_FUNCS)
 def test_agg_vector(backend, func, simple_data):
-    if backend.name == 'sqlite':
-        pytest.skip()
-
     df = backend.load_cached_df(simple_data)
 
     res = data_frame(y = func(simple_data))
@@ -120,9 +114,6 @@ def test_agg_vector(backend, func, simple_data):
 @backend_sql
 @pytest.mark.parametrize('func', VECTOR_FILTER_FUNCS)
 def test_filter_vector(backend, func, simple_data):
-    if backend.name == 'sqlite':
-        pytest.skip()
-
     df = backend.load_cached_df(simple_data)
 
     res = data_frame(y = func(simple_data))
@@ -147,8 +138,6 @@ def test_filter_vector(backend, func, simple_data):
 #@given(DATA_SPEC)
 #@settings(max_examples = 50, deadline = 1000)
 #def test_hypothesis_mutate_vector_funcs(backend, data):
-#    if backend.name == 'sqlite':
-#        pytest.skip()
 #
 #    df = backend.load_df(data)
 #    

--- a/siuba/tests/test_verb_arrange.py
+++ b/siuba/tests/test_verb_arrange.py
@@ -50,7 +50,6 @@ def test_arrange_grouped_trivial(df):
             DATA.sort_values(['x'])
             )
 
-@backend_notimpl("sqlite")
 def test_arrange_grouped(backend, df):
     q = group_by(_.y) >> arrange(_.x)
     assert_equal_query(
@@ -70,7 +69,6 @@ def test_arrange_grouped(backend, df):
 # SQL -------------------------------------------------------------------------
 
 @backend_sql
-@backend_notimpl("sqlite")
 def test_no_arrange_before_cuml_window_warning(backend):
     data = data_frame(x = range(1, 5), g = [1,1,2,2])
     dfs = backend.load_df(data)

--- a/siuba/tests/test_verb_filter.py
+++ b/siuba/tests/test_verb_filter.py
@@ -31,7 +31,6 @@ def test_filter_basic_two_args(backend):
 
     assert_equal_query(dfs, filter(_.x > 3, _.y < 2), df[lambda _: (_.x > 3) & (_.y < 2)])
 
-@backend_notimpl("sqlite")
 def test_filter_via_group_by(backend):
     df = data_frame(
             x = range(1, 11),
@@ -48,7 +47,6 @@ def test_filter_via_group_by(backend):
             )
 
 
-@backend_notimpl("sqlite")
 def test_filter_via_group_by_agg(backend):
     dfs = backend.load_df(x = range(1,11), g = [1]*5 + [2]*5)
 
@@ -59,7 +57,6 @@ def test_filter_via_group_by_agg(backend):
             )
 
 
-@backend_notimpl("sqlite")
 def test_filter_via_group_by_agg_two_args(backend):
     dfs = backend.load_df(x = range(1,11), g = [1]*5 + [2]*5)
 
@@ -71,7 +68,6 @@ def test_filter_via_group_by_agg_two_args(backend):
 
 
 @backend_sql("TODO: pandas - implement arrange over group by")
-@backend_notimpl("sqlite")
 def test_filter_via_group_by_arrange(backend):
     dfs = backend.load_df(x = [3,2,1] + [2,3,4], g = [1]*3 + [2]*3)
 
@@ -82,7 +78,6 @@ def test_filter_via_group_by_arrange(backend):
             )
 
 @backend_sql("TODO: pandas - implement arrange over group by")
-@backend_notimpl("sqlite")
 def test_filter_via_group_by_desc_arrange(backend):
     dfs = backend.load_df(x = [3,2,1] + [2,3,4], g = [1]*3 + [2]*3)
 
@@ -103,7 +98,6 @@ def test_filter_before_summarize(backend):
             check_dtype=False
             )
 
-@backend_notimpl("sqlite")
 def test_filter_before_summarize_grouped(backend):
     dfs = backend.load_df(x = [1,2,3], g = ["a", "a", "b"])
 

--- a/siuba/tests/test_verb_mutate.py
+++ b/siuba/tests/test_verb_mutate.py
@@ -19,7 +19,7 @@ def dfs(backend):
 
 @pytest.mark.parametrize("query, output", [
     (mutate(x = _.a + _.b), DATA.assign(x = [10, 10, 10])),
-    pytest.param( mutate(x = _.a + _.b) >> summarize(ttl = _.x.sum()), data_frame(ttl = 30.0), marks = pytest.mark.skip("TODO: failing sqlite?")),
+    (mutate(x = _.a + _.b) >> summarize(ttl = _.x.sum().astype(float)), data_frame(ttl = 30.0)),
     (mutate(x = _.a + 1, y = _.b - 1), DATA.assign(x = [2,3,4], y = [8,7,6])),
     (mutate(x = _.a + 1) >> mutate(y = _.b - 1), DATA.assign(x = [2,3,4], y = [8,7,6])),
     (mutate(x = _.a + 1, y = _.x + 1), DATA.assign(x = [2,3,4], y = [3,4,5]))
@@ -75,7 +75,6 @@ def test_mutate_reassign_all_cols_keeps_rowsize(dfs):
             )
 
 @backend_sql
-@backend_notimpl("sqlite")
 def test_mutate_window_funcs(backend):
     data = data_frame(idx = range(0, 4), x = range(1, 5), g = [1,1,2,2])
     dfs = backend.load_df(data)
@@ -86,7 +85,6 @@ def test_mutate_window_funcs(backend):
             )
 
 
-@backend_notimpl("sqlite")
 def test_mutate_using_agg_expr(backend):
     data = data_frame(x = range(1, 5), g = [1,1,2,2])
     dfs = backend.load_df(data)
@@ -97,7 +95,6 @@ def test_mutate_using_agg_expr(backend):
             )
 
 @backend_sql # TODO: pandas outputs a int column
-@backend_notimpl("sqlite")
 def test_mutate_using_cuml_agg(backend):
     data = data_frame(idx = range(0, 4), x = range(1, 5), g = [1,1,2,2])
     dfs = backend.load_df(data)

--- a/siuba/tests/test_verb_summarize.py
+++ b/siuba/tests/test_verb_summarize.py
@@ -39,7 +39,6 @@ def test_ungrouped_summarize_literal(df):
     assert_equal_query(df, summarize(y = 1), data_frame(y = 1)) 
 
 
-@backend_notimpl("sqlite")
 def test_summarize_after_mutate_cuml_win(backend, df_float):
     assert_equal_query(
             df_float,


### PR DESCRIPTION
This PR does the following:

* implements window functions (which sqlite started supporting a few years ago)
  - includes dply vector functions. E.g. `dense_rank()`
* implements some aggs which I thought sqlite didn't support (e.g. `n()`)
* remove most cases of skipping sqlite from unit tests!
* fixes failing bigquery tests (that were accidentally skipped on CI)