### PR TITLE
fix: mock_sqlalchemy_engine across dialects, collecting

### DIFF
--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -29,7 +29,15 @@ from siuba.dply.verbs import (
         )
 
 from .translate import CustomOverClause, SqlColumn, SqlColumnAgg
-from .utils import get_dialect_translator, _FixedSqlDatabase, _sql_select, _sql_column_collection, _sql_add_columns, _sql_with_only_columns
+from .utils import (
+    get_dialect_translator,
+    _FixedSqlDatabase,
+    _sql_select,
+    _sql_column_collection,
+    _sql_add_columns,
+    _sql_with_only_columns,
+    MockConnection
+)
 
 from sqlalchemy import sql
 import sqlalchemy
@@ -466,6 +474,12 @@ def _collect(__data, as_df = True):
     #    dialect = __data.source.dialect,
     #    compile_kwargs = {"literal_binds": True}
     #)
+
+    if isinstance(__data.source, MockConnection):
+        # a mock sqlalchemy is being used to show_query, and echo queries.
+        # it doesn't return a result object or have a context handler, so
+        # we need to bail out early
+        return
 
     with __data.source.connect() as conn:
         if as_df:

--- a/siuba/tests/test_sql_utils.py
+++ b/siuba/tests/test_sql_utils.py
@@ -1,4 +1,6 @@
-from siuba.sql.utils import get_dialect_translator
+from siuba.sql.utils import get_dialect_translator, mock_sqlalchemy_engine
+from siuba.sql.verbs import collect
+from siuba.sql import LazyTbl
 import pytest
 
 @pytest.mark.parametrize('name', [
@@ -8,3 +10,15 @@ import pytest
     ])
 def test_get_dialect_translator(name):
     get_dialect_translator(name)
+
+def test_mock_sqlalchemy_engine_dialect():
+    engine = mock_sqlalchemy_engine("postgresql")
+    assert engine.dialect.name == "postgresql"
+
+    engine = mock_sqlalchemy_engine("sqlite")
+    assert engine.dialect.name == "sqlite"
+
+def test_mock_sqlalchemy_engine_no_collect():
+    engine = mock_sqlalchemy_engine("sqlite")
+    tbl = LazyTbl(engine, "some_table", ["x"])
+    assert collect(tbl) is None


### PR DESCRIPTION
Fixes issues with mock_sqlalchemy_engine:

* dialect parameter wasn't being used (every mock engine used postgresql dialect)
* collect on a LazyTbl using a mocked engine no longer errors. It now returns None.

See #407 