### PR TITLE
Feat sql over

### DIFF
--- a/siuba/siu/visitors.py
+++ b/siuba/siu/visitors.py
@@ -320,5 +320,6 @@ class CodataVisitor(ExecutionValidatorVisitor):
                     *node.args[1:],
                     **node.kwargs
                     )
+        return node
 
 

--- a/siuba/sql/__init__.py
+++ b/siuba/sql/__init__.py
@@ -1,5 +1,5 @@
-from .verbs import LazyTbl, sql_raw, SqlFunctionLookupError
-from .translate import SqlColumn, SqlColumnAgg
+from .verbs import LazyTbl, sql_raw
+from .translate import SqlColumn, SqlColumnAgg, SqlFunctionLookupError
 
 # preceed w/ underscore so it isn't exported by default
 # we just want to register the singledispatch funcs

--- a/siuba/sql/translate.py
+++ b/siuba/sql/translate.py
@@ -18,10 +18,14 @@ It is broken into 5 sections:
 
 from sqlalchemy import sql
 
-from siuba.siu import FunctionLookupBound
+from siuba.siu import FunctionLookupBound, FunctionLookupError
+
 
 # warning for when sql defaults differ from pandas ============================
 import warnings
+
+
+class SqlFunctionLookupError(FunctionLookupError): pass
 
 
 class SiubaSqlRuntimeWarning(UserWarning): pass
@@ -243,14 +247,15 @@ def wrap_annotate(f, **kwargs):
 
 #  Translator =================================================================
 
+from siuba.ops.translate import create_pandas_translator
+
+
 def extend_base(cls, **kwargs):
     """Register concrete methods onto generic functions for pandas Series methods."""
     from siuba.ops import ALL_OPS
     for meth_name, f in kwargs.items():
         ALL_OPS[meth_name].register(cls, f)
 
-
-from siuba.ops.translate import create_pandas_translator
 
 # TODO: should inherit from a ITranslate class (w/ abstract translate method)
 class SqlTranslator:
@@ -300,7 +305,7 @@ class SqlTranslator:
             verb_name = None, arg_name = None,
             ):
 
-        from siuba.siu import Call, MetaArg, strip_symbolic
+        from siuba.siu import Call, MetaArg, strip_symbolic, Lazy
         from siuba.siu.visitors import CodataVisitor
 
         call = strip_symbolic(call)

--- a/siuba/sql/translate.py
+++ b/siuba/sql/translate.py
@@ -308,7 +308,7 @@ class SqlTranslator:
             ):
         """Return a siu Call that creates dialect specific SQL when called."""
 
-        from siuba.siu import Call, MetaArg, strip_symbolic, Lazy
+        from siuba.siu import Call, MetaArg, strip_symbolic, Lazy, str_to_getitem_call
         from siuba.siu.visitors import CodataVisitor
 
         call = strip_symbolic(call)

--- a/siuba/sql/translate.py
+++ b/siuba/sql/translate.py
@@ -293,6 +293,8 @@ class SqlTranslator:
         self.aggregate = aggregate
 
     def translate(self, expr, window = True):
+        """Convert an AST of method chains to an AST of function calls."""
+
         if window:
             return self.window.translate(expr)
 
@@ -304,6 +306,7 @@ class SqlTranslator:
             call, window = True, str_accessors = False,
             verb_name = None, arg_name = None,
             ):
+        """Return a siu Call that creates dialect specific SQL when called."""
 
         from siuba.siu import Call, MetaArg, strip_symbolic, Lazy
         from siuba.siu.visitors import CodataVisitor

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -148,13 +148,13 @@ class WindowReplacer(CallListener):
         return windows
 
 
+#def track_call_windows(call, columns, group_by, order_by, window_cte = None):
+#    listener = WindowReplacer(columns, group_by, order_by, window_cte)
+#    col = listener.enter(call)
+#    return col, listener.windows, listener.window_cte
+
+
 def track_call_windows(call, columns, group_by, order_by, window_cte = None):
-    listener = WindowReplacer(columns, group_by, order_by, window_cte)
-    col = listener.enter(call)
-    return col, listener.windows, listener.window_cte
-
-
-def track_call_windows2(call, columns, group_by, order_by, window_cte = None):
     col_expr = call(columns)
 
     if not isinstance(col_expr, sql.elements.ClauseElement):
@@ -162,16 +162,16 @@ def track_call_windows2(call, columns, group_by, order_by, window_cte = None):
 
     over_clauses = WindowReplacer._get_over_clauses(col_expr)
 
+    crnt_group_by = sql.elements.ClauseList(
+            *[columns[name] for name in group_by]
+            )
+    crnt_order_by = sql.elements.ClauseList(
+            *_create_order_by_clause(columns, *order_by)
+            )
+
     for over in over_clauses:
         # TODO: shouldn't mutate these over clauses
-        group_by = sql.elements.ClauseList(
-                *[columns[name] for name in group_by]
-                )
-        order_by = sql.elements.ClauseList(
-                *_create_order_by_clause(columns, *order_by)
-                )
-
-        over.set_over(group_by, order_by)
+        over.set_over(crnt_group_by, crnt_order_by)
 
     if len(over_clauses) and window_cte is not None:
         # custom name, or parameters like "%(...)s" may nest and break psycopg2
@@ -187,7 +187,7 @@ def track_call_windows2(call, columns, group_by, order_by, window_cte = None):
         window_cte = _sql_add_columns(window_cte, [label])
         win_col = lift_inner_cols(window_cte).values()[-1]
 
-        return win_col
+        return win_col, over_clauses, window_cte
             
     return col_expr, over_clauses, window_cte
 
@@ -497,6 +497,7 @@ def _show_query(tbl, simplify = False):
         print(compile_query())
 
     return tbl
+
 
 # collect ----------
 

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -157,21 +157,26 @@ class WindowReplacer(CallListener):
 def track_call_windows(call, columns, group_by, order_by, window_cte = None):
     col_expr = call(columns)
 
-    if not isinstance(col_expr, sql.elements.ClauseElement):
-        return col_expr
-
-    over_clauses = WindowReplacer._get_over_clauses(col_expr)
-
     crnt_group_by = sql.elements.ClauseList(
             *[columns[name] for name in group_by]
             )
     crnt_order_by = sql.elements.ClauseList(
             *_create_order_by_clause(columns, *order_by)
             )
+    return replace_call_windows(col_expr, crnt_group_by, crnt_order_by, window_cte)
+
+
+
+def replace_call_windows(col_expr, group_by, order_by, window_cte = None):
+
+    if not isinstance(col_expr, sql.elements.ClauseElement):
+        return col_expr
+
+    over_clauses = WindowReplacer._get_over_clauses(col_expr)
 
     for over in over_clauses:
         # TODO: shouldn't mutate these over clauses
-        over.set_over(crnt_group_by, crnt_order_by)
+        over.set_over(group_by, order_by)
 
     if len(over_clauses) and window_cte is not None:
         # custom name, or parameters like "%(...)s" may nest and break psycopg2
@@ -301,49 +306,7 @@ class LazyTbl:
             call, window = True, str_accessors = False,
             verb_name = None, arg_name = None,
             ):
-        if isinstance(call, Call):
-            pass
-        elif str_accessors and isinstance(call, str):
-            # verbs that can use strings as accessors, like group_by, or
-            # arrange, need to convert those strings into a getitem call
-            return str_to_getitem_call(call)
-        elif isinstance(call, sql.elements.ColumnClause):
-            return Lazy(call)
-        elif callable(call):
-            #TODO: should not happen here
-            from siuba.siu import MetaArg
-            return Call("__call__", call, MetaArg('_'))
-
-        else:
-            # verbs that use literal strings, need to convert them to a call
-            # that returns a sqlalchemy "literal" object
-            return Lazy(sql.literal(call))
-
-        # raise informative error message if missing translation
-        try:
-            # TODO: MC-NOTE -- scaffolding in to verify prior behavior works
-            from siuba.siu.visitors import CodataVisitor
-            shaped_call = self.translator.translate(call, window = window)
-            if window:
-                trans = self.translator.window
-            else:
-                trans = self.translator.aggregate
-
-            # TODO: MC-NOTE - once all sql singledispatch funcs are annotated
-            # with return types, then switch object back out
-            # alternatively, could register a bounding class, and remove
-            # the result type check
-            v = CodataVisitor(trans.dispatch_cls, object)
-            return v.visit(shaped_call)
-            
-        except FunctionLookupError as err:
-            raise SqlFunctionLookupError.from_verb(
-                    verb_name or "Unknown",
-                    arg_name or "Unknown",
-                    err,
-                    short = True
-                    )
-
+        return self.translator.shape_call(call, window, str_accessors, verb_name, arg_name)
 
     def track_call_windows(self, call, columns = None, window_cte = None):
         """Returns tuple of (new column expression, list of window exprs)"""

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -41,7 +41,7 @@ from .utils import (
 
 from sqlalchemy import sql
 import sqlalchemy
-from siuba.siu import Call, str_to_getitem_call, Lazy, FunctionLookupError, singledispatch2
+from siuba.siu import Call, Lazy, FunctionLookupError, singledispatch2
 # TODO: currently needed for select, but can we remove pandas?
 from pandas import Series
 

--- a/siuba/tests/test_sql_verbs.py
+++ b/siuba/tests/test_sql_verbs.py
@@ -73,6 +73,16 @@ def test_lazy_tbl_shape_call_error(db):
         assert err.__suppress_context__ == True
 
 
+# track_call_windows ----------------------------------------------------------
+
+from siuba.sql.verbs import track_call_windows
+from siuba.sql.translate import win_over
+
+def test_track_call_windows_basic():
+    pass
+
+
+    
 
 # TODO: remove these old tests? should be redundant ===========================
 

--- a/siuba/tests/test_verb_group_by.py
+++ b/siuba/tests/test_verb_group_by.py
@@ -20,13 +20,20 @@ def df(backend):
     return backend.load_df(DATA)
 
 
-def test_group_by_no_add(df):
+def test_group_by_two(df):
     gdf = group_by(df, _.x, _.y)
     assert gdf.group_by == ("x", "y")
 
 def test_group_by_override(df):
     gdf = df >> group_by(_.x, _.y) >> group_by(_.g)
     assert gdf.group_by == ("g",)
+
+def test_group_by_no_add(df):
+    # without add argument, group_by overwrites prev grouping
+    gdf1 = group_by(df, _.x)
+    gdf2 = group_by(gdf1, _.y)
+
+    assert gdf2.group_by == ("y",)
 
 def test_group_by_add(df):
     gdf = group_by(df, _.x) >> group_by(_.y, add = True)
@@ -40,6 +47,9 @@ def test_group_by_ungroup(df):
     q2 = q1 >> ungroup()
     assert q2.group_by == tuple()
 
+def test_group_by_using_string(df):
+    gdf = group_by(df, "g") >> summarize(res = _.x.mean())
+    
 
 @pytest.mark.skip("TODO: need to test / validate joins first")
 def test_group_by_before_joins(df):


### PR DESCRIPTION
* Rewrites track_call_windows from using a visitor class, to being a simple function (the visiting was unnecessary, and had the undesired effect of repeating windows that were components of a larger expression in the inner select)
* Moves LazyTbl.shape_call() logic to be a method on the SqlTranslator class