### PR TITLE
feat: duckdb support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install -r requirements-test.txt
           # step to test duckdb
           # TODO: move these requirements into the test matrix
-          pip install duckdb_engine
+          pip install git+https://github.com/Mause/duckdb_engine.git
           python -m pip install .
         env:
           REQUIREMENTS: ${{ matrix.requirements }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install $REQUIREMENTS
           python -m pip install -r requirements-test.txt
+          # step to test duckdb
+          # TODO: move these requirements into the test matrix
+          pip install duckdb_engine
           python -m pip install .
         env:
           REQUIREMENTS: ${{ matrix.requirements }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install -r requirements-test.txt
           # step to test duckdb
           # TODO: move these requirements into the test matrix
-          pip install git+https://github.com/Mause/duckdb_engine.git
+          pip install duckdb_engine
           python -m pip install .
         env:
           REQUIREMENTS: ${{ matrix.requirements }}

--- a/siuba/ops/support/base.py
+++ b/siuba/ops/support/base.py
@@ -8,7 +8,7 @@ from siuba.ops import ALL_OPS
 from siuba.siu import FunctionLookupBound
 from siuba.sql.utils import get_dialect_translator
 
-SQL_BACKENDS = ["postgresql", "redshift", "sqlite", "mysql", "bigquery", "snowflake"]
+SQL_BACKENDS = ["postgresql", "redshift", "sqlite", "mysql", "bigquery", "snowflake", "duckdb"]
 ALL_BACKENDS = SQL_BACKENDS + ["pandas"]
 
 methods = pd.DataFrame(

--- a/siuba/sql/dialects/_dt_generics.py
+++ b/siuba/sql/dialects/_dt_generics.py
@@ -14,7 +14,7 @@ def date_trunc(_, col, period):
 
 @symbolic_dispatch(cls = SqlColumn)
 def sql_func_last_day_in_period(codata, col, period):
-    return date_trunc(codata, col, period) + sql.text("interval '1 %s - 1 day'" % period)
+    return date_trunc(codata, col, period) + sql.text("INTERVAL '1 %s' - INTERVAL '1 day'" % period)
 
 
 # TODO: RENAME TO GEN

--- a/siuba/sql/dialects/base.py
+++ b/siuba/sql/dialects/base.py
@@ -368,7 +368,7 @@ extend_base(SqlColumn,
     cummax                  = win_cumul("max"),
     cummin                  = win_cumul("min"),
     #cumprod                 = 
-    cumsum                  = annotate(win_cumul("sum"), result_type = "float"),
+    cumsum                  = annotate(win_cumul("sum"), result_type = "variable"),
     diff                    = sql_func_diff,
     #is_monotonic            = 
     #is_monotonic_decreasing = 
@@ -397,7 +397,7 @@ extend_base(SqlColumn,
     #sem = 
     #skew = 
     #std =  # TODO(pg)
-    sum = annotate(win_agg("sum"), result_type = "float"),
+    sum = annotate(win_agg("sum"), result_type = "variable"),
     #var = # TODO(pg)
 
 

--- a/siuba/sql/dialects/duckdb.py
+++ b/siuba/sql/dialects/duckdb.py
@@ -92,8 +92,6 @@ returns_int([
 
 extend_base(
     DuckdbColumn,
-    cumsum = win_cumul("sum"),
-    sum = win_agg("sum"),
     rank = sql_func_rank,
     #quantile = sql_quantile(is_analytic=True),
 )
@@ -103,7 +101,6 @@ extend_base(
 
 extend_base(
     DuckdbColumnAgg,
-    sum = sql_agg("sum"),
     quantile = sql_quantile(),
 )
 

--- a/siuba/sql/dialects/duckdb.py
+++ b/siuba/sql/dialects/duckdb.py
@@ -1,0 +1,111 @@
+from sqlalchemy.sql import func as fn
+from sqlalchemy import sql
+
+from ..translate import (
+    # data types
+    SqlColumn, SqlColumnAgg,
+    AggOver,
+    # transformations
+    wrap_annotate,
+    sql_agg,
+    win_agg,
+    win_cumul,
+    sql_not_impl,
+    # wiring up translator
+    extend_base,
+    SqlTranslator
+)
+
+from .postgresql import (
+    PostgresqlColumn,
+    PostgresqlColumnAgg,
+)
+
+from .base import sql_func_rank
+
+
+# Data ========================================================================
+
+class DuckdbColumn(PostgresqlColumn): pass
+class DuckdbColumnAgg(PostgresqlColumnAgg, DuckdbColumn): pass
+
+
+# Annotations =================================================================
+
+def returns_int(func_names):
+    # TODO: MC-NOTE - shift all translations to directly register
+    # TODO: MC-NOTE - make an AliasAnnotated class or something, that signals
+    #                 it is using another method, but w/ an updated annotation.
+    from siuba.ops import ALL_OPS
+    
+    for name in func_names:
+        generic = ALL_OPS[name]
+        f_concrete = generic.dispatch(SqlColumn)
+        f_annotated = wrap_annotate(f_concrete, result_type="int")
+        generic.register(DuckdbColumn, f_annotated)
+    
+
+# Translations ================================================================
+
+
+def sql_quantile(is_analytic=False):
+    # Ordered and theoretical set aggregates
+    sa_func = getattr(sql.func, "percentile_cont")
+
+    def f_quantile(codata, col, q, *args):
+        if args:
+            raise NotImplementedError("Quantile only supports the q argument.")
+        if not isinstance(q, (int, float)):
+            raise TypeError("q argument must be int or float, but received: %s" %type(q))
+
+        # as far as I can tell, there's no easy way to tell sqlalchemy to render
+        # the exact text a dialect would render for a literal (except maybe using
+        # literal_column), so use the classic sql.text.
+        q_text = sql.text(str(q))
+
+        if is_analytic:
+            return AggOver(sa_func(sql.text(q_text)).within_group(col))
+
+        return sa_func(q_text).within_group(col)
+
+    return f_quantile
+
+
+# scalar ----
+
+extend_base(
+    DuckdbColumn,
+    **{
+        "str.contains": lambda _, col, re: fn.regexp_matches(col, re),
+        "str.title": sql_not_impl(),
+    }
+)
+
+returns_int([
+    "dt.day", "dt.dayofyear", "dt.days_in_month",
+    "dt.daysinmonth", "dt.hour", "dt.minute", "dt.month",
+    "dt.quarter", "dt.second", "dt.week",
+    "dt.weekofyear", "dt.year"
+])
+
+# window ----
+
+extend_base(
+    DuckdbColumn,
+    cumsum = win_cumul("sum"),
+    sum = win_agg("sum"),
+    rank = sql_func_rank,
+    #quantile = sql_quantile(is_analytic=True),
+)
+
+
+# aggregate ----
+
+extend_base(
+    DuckdbColumnAgg,
+    sum = sql_agg("sum"),
+    quantile = sql_quantile(),
+)
+
+
+translator = SqlTranslator.from_mappings(DuckdbColumn, DuckdbColumnAgg)

--- a/siuba/sql/dialects/postgresql.py
+++ b/siuba/sql/dialects/postgresql.py
@@ -31,7 +31,7 @@ class PostgresqlColumnAgg(SqlColumnAgg, PostgresqlColumn): pass
 
 @annotate(return_type="float")
 def sql_is_quarter_end(_, col):
-    last_day = fn.date_trunc("quarter", col) + sql.text("interval '3 month - 1 day'")
+    last_day = fn.date_trunc("quarter", col) + sql.text("INTERVAL '3 month' - INTERVAL '1 day'")
     return fn.date_trunc("day", col) == last_day
 
 

--- a/siuba/sql/dply/vector.py
+++ b/siuba/sql/dply/vector.py
@@ -12,6 +12,7 @@ from ..translate import (
 from ..dialects.sqlite import SqliteColumn
 from ..dialects.mysql import MysqlColumn
 from ..dialects.bigquery import BigqueryColumn
+from ..dialects.duckdb import DuckdbColumn
 
 from siuba.dply.vector import (
         #cumall, cumany, cummean,
@@ -99,7 +100,7 @@ min_rank    .register(MysqlColumn, _sql_rank("rank", partition = True))
 dense_rank  .register(BigqueryColumn, _sql_rank("dense_rank", nulls_last = True))
 percent_rank.register(BigqueryColumn, _sql_rank("percent_rank", nulls_last = True))
 
-
+dense_rank  .register(DuckdbColumn, _sql_rank("dense_rank", nulls_last = True))
 
 # row_number ------------------------------------------------------------------
 

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -46,9 +46,13 @@ def mock_sqlalchemy_engine(dialect):
 
     """
 
-    from sqlalchemy.engine import Engine, URL
+    from sqlalchemy.engine import Engine
     from sqlalchemy.dialects import registry
     from types import ModuleType
+
+    #  TODO: can be removed once v1.3.18 support dropped
+    from sqlalchemy.engine.url import URL
+
 
     dialect_cls = registry.load(dialect)
 
@@ -59,7 +63,15 @@ def mock_sqlalchemy_engine(dialect):
         dialect_cls = dialect_cls.dialect
     
     conn = MockConnection(dialect_cls(), lambda *args, **kwargs: None)
-    conn.url = URL.create(drivername=dialect)
+
+    # set a url on it, so that LazyTbl can read the backend name.
+    if is_sqla_12() or is_sqla_13():
+        url = URL(drivername=dialect)
+    else:
+        url = URL.create(drivername=dialect)
+
+    conn.url = url
+
     return conn
 
 

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -49,8 +49,15 @@ def mock_sqlalchemy_engine(dialect):
 
     from sqlalchemy.engine import Engine
     from sqlalchemy.dialects import registry
+    from types import ModuleType
 
     dialect_cls = registry.load(dialect)
+
+    # there is probably a better way to do this, but for some reason duckdb
+    # returns a module, rather than the dialect class itself. By convention,
+    # dialect modules expose a variable named dialect, so we grab that.
+    if isinstance(dialect_cls, ModuleType):
+        dialect_cls = dialect_cls.dialect
     
     return MockConnection(dialect_cls(), lambda *args, **kwargs: None)
 

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -32,6 +32,7 @@ from .translate import CustomOverClause, SqlColumn, SqlColumnAgg
 from .utils import (
     get_dialect_translator,
     _FixedSqlDatabase,
+    _is_dialect_duckdb,
     _sql_select,
     _sql_column_collection,
     _sql_add_columns,
@@ -281,7 +282,8 @@ class LazyTbl:
         # connection and dialect specific functions
         self.source = sqlalchemy.create_engine(source) if isinstance(source, str) else source
 
-        dialect = self.source.dialect.name
+        # get dialect name
+        dialect = self.source.url.get_backend_name()
         self.translator = get_dialect_translator(dialect)
 
         self.tbl = self._create_table(tbl, columns, self.source)
@@ -476,7 +478,7 @@ def _collect(__data, as_df = True):
 
     # compile query ----
 
-    if __data.source.engine.dialect.name == "duckdb":
+    if _is_dialect_duckdb(__data.source):
         # TODO: can be removed once next release of duckdb fixes:
         # https://github.com/duckdb/duckdb/issues/2972
         query = __data.last_op
@@ -493,7 +495,7 @@ def _collect(__data, as_df = True):
         if as_df:
             sql_db = _FixedSqlDatabase(conn)
 
-            if __data.source.engine.dialect.name == "duckdb":
+            if _is_dialect_duckdb(__data.source):
                 # TODO: pandas read_sql is very slow with duckdb.
                 # see https://github.com/pandas-dev/pandas/issues/45678
                 # going to handle here for now. address once LazyTbl gets

--- a/siuba/tests/conftest.py
+++ b/siuba/tests/conftest.py
@@ -17,6 +17,7 @@ params_backend = [
     pytest.param(lambda: SqlBackend("postgresql"), id = "postgresql", marks=pytest.mark.postgresql),
     pytest.param(lambda: SqlBackend("mysql"), id = "mysql", marks=pytest.mark.mysql),
     pytest.param(lambda: SqlBackend("sqlite"), id = "sqlite", marks=pytest.mark.sqlite),
+    pytest.param(lambda: SqlBackend("duckdb"), id = "duckdb", marks=pytest.mark.duckdb),
     pytest.param(lambda: BigqueryBackend("bigquery"), id = "bigquery", marks=pytest.mark.bigquery),
     pytest.param(lambda: CloudBackend("snowflake"), id = "snowflake", marks=pytest.mark.snowflake),
     pytest.param(lambda: PandasBackend("pandas"), id = "pandas", marks=pytest.mark.pandas)

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -2,6 +2,7 @@ import sqlalchemy as sqla
 import uuid
 
 from siuba.sql import LazyTbl
+from siuba.sql.utils import _is_dialect_duckdb
 from siuba.dply.verbs import ungroup, collect
 from siuba.siu import FunctionLookupError
 from pandas.testing import assert_frame_equal
@@ -226,7 +227,7 @@ def assert_equal_query(tbl, lazy_query, target, **kwargs):
 
     out = collect(lazy_query(tbl))
 
-    if isinstance(tbl, LazyTbl) and tbl.source.dialect.name == "duckdb":
+    if isinstance(tbl, LazyTbl) and _is_dialect_duckdb(tbl.source):
         # TODO: find a nice way to remove duckdb specific code from here
         # duckdb does not use pandas.DataFrame.to_sql method, which coerces
         # everything to 64 bit. So we need to coerce any results it returns

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -232,8 +232,8 @@ def assert_equal_query(tbl, lazy_query, target, **kwargs):
         # duckdb does not use pandas.DataFrame.to_sql method, which coerces
         # everything to 64 bit. So we need to coerce any results it returns
         # as 32 bit to 64 bit, to match to_sql.
-        int_cols = out.select_dtypes('int').columns
-        flt_cols = out.select_dtypes('float').columns
+        int_cols = out.select_dtypes('int32').columns
+        flt_cols = out.select_dtypes('float32').columns
         out[int_cols] = out[int_cols].astype('int64')
         out[flt_cols] = out[flt_cols].astype('float64')
 

--- a/siuba/tests/test_sql_misc.py
+++ b/siuba/tests/test_sql_misc.py
@@ -35,8 +35,14 @@ def test_raw_sql_mutate_grouped(backend, df):
 @backend_sql
 def test_raw_sql_mutate_refer_previous_raise_dberror(backend, skip_backend, df):
     # Note: unlikely will be able to support this case. Normally we analyze
-    # the expression to know whether we need to create a subquery.
-    with pytest.raises(sqlalchemy.exc.DatabaseError):
+    if backend.name == "duckdb":
+        # duckdb dialect re-raises the engines exception, which is RuntimeError
+        # the expression to know whether we need to create a subquery.
+        exc = RuntimeError
+    else:
+        exc = sqlalchemy.exc.DatabaseError
+
+    with pytest.raises(exc):
         assert_equal_query(
                 df,
                 group_by("x") >> mutate(z1 = sql_raw("y + 1"), z2 = sql_raw("z1 + 1")),
@@ -44,7 +50,7 @@ def test_raw_sql_mutate_refer_previous_raise_dberror(backend, skip_backend, df):
                 )
 
 
-@pytest.mark.xfail_backend("postgresql", "mysql", "bigquery", "sqlite")
+@pytest.mark.xfail_backend("postgresql", "mysql", "bigquery", "sqlite", "duckdb")
 @backend_sql
 def test_raw_sql_mutate_refer_previous_succeeds(backend, xfail_backend, df):
     assert_equal_query(

--- a/siuba/tests/test_sql_verbs.py
+++ b/siuba/tests/test_sql_verbs.py
@@ -32,15 +32,16 @@ def db():
 
     metadata.create_all(engine)
 
-    conn = engine.connect()
+    with engine.connect() as conn:
 
-    ins = users.insert().values(name='jack', fullname='Jack Jones')
-    result = conn.execute(ins)
+        ins = users.insert().values(name='jack', fullname='Jack Jones')
+        result = conn.execute(ins)
 
 
-    ins = users.insert()
-    conn.execute(ins, id=2, name='wendy', fullname='Wendy Williams')
-    yield conn
+        ins = users.insert()
+        conn.execute(ins, id=2, name='wendy', fullname='Wendy Williams')
+
+    yield engine
 
 # LazyTbl ---------------------------------------------------------------------
 

--- a/siuba/tests/test_verb_count.py
+++ b/siuba/tests/test_verb_count.py
@@ -49,7 +49,7 @@ def test_count_with_kwarg_expression(df):
             pd.DataFrame({"y": [0], "n": [4]})
             )
 
-@backend_notimpl("sqlite", "postgresql", "mysql", "bigquery", "snowflake") # see (#104)
+@backend_notimpl("sql") # see (#104)
 def test_count_wt(backend, df):
     assert_equal_query(
             df,
@@ -65,7 +65,7 @@ def test_count_no_groups(df):
             pd.DataFrame({'n': [4]})
             )
 
-@backend_notimpl("sqlite", "postgresql", "mysql", "bigquery", "snowflake")   # see (#104)
+@backend_notimpl("sql")   # see (#104)
 def test_count_no_groups_wt(backend, df):
     assert_equal_query(
             df,


### PR DESCRIPTION
re-implementation of #380

Notes:

* This requires the code on master of https://github.com/Mause/duckdb_engine.
* Contains a patch to fix the issue in #380 of literal ints being interpreted as strings. Basically, for duckdb we bind literals when executing the query, so that there are no parameters. Once https://github.com/duckdb/duckdb/issues/2972 is released, can remove the patch.

Edit: Updated notes (May 30th):

* Breaking: LazyTbl now gets the dialect name from sqlalchemy's URL, to work around needing dialects to set the correct name. This means LazyTbl must take an Engine, not a connection (which seems weird to pass it anyway).
* I added a temporary `_is_dialect_duckdb` function to handle these edge cases:
  - `collect()` uses duckdb's query(...).to_df() method
  - `collect()` binds literals when compiling query
  - assert_equal_query coerces a duckdb `to_df()` result to use 64 bit column types (e.g. int64, float64). This is to match pandas to_sql behavior (which coerces everything to 64 bit). This is just to make testing easier. Could annotate duckdb translations with `result_type="variable"` to tell the tests not to check exact dtypes.

## Example

```python
from siuba.data import mtcars
from siuba.sql import LazyTbl
from siuba import _, mutate, group_by, filter

from sqlalchemy import create_engine

engine = create_engine("duckdb:///:memory")
engine.execute("register", ("some_df", mtcars))

tbl = LazyTbl(engine, "some_df")

# mutation ----
tbl >> mutate(res = _.hp - _.hp.mean(), res2 = _.res * 2)

# group by cylinder, and filter all entries less than the mean ----
tbl >> group_by(_.cyl) >> filter(_.hp < _.hp.mean())
```