### PR TITLE
forcats functions: fct_inseq, fct_infreq

### DIFF
--- a/siuba/dply/forcats.py
+++ b/siuba/dply/forcats.py
@@ -83,7 +83,9 @@ def fct_inorder(fct, ordered=None):
             categories = uniq.categories[uniq.dropna().codes]
             return pd.Categorical(fct, categories, ordered=ordered)
 
-        return pd.Categorical(fct, uniq, ordered=ordered)
+        # series in, so series out
+        cat = pd.Categorical(fct, uniq, ordered=ordered)
+        return pd.Series(cat)
 
     ser = pd.Series(fct)
     return pd.Categorical(fct, categories = ser.dropna().unique(), ordered=ordered)
@@ -137,7 +139,12 @@ def fct_infreq(fct, ordered=None):
         # Series sorts in descending frequency order
         ser = pd.Series(fct) if not isinstance(fct, pd.Series) else fct
         freq = ser.value_counts()
-        return pd.Categorical(ser, categories=freq.index, ordered=ordered)
+        cat = pd.Categorical(ser, categories=freq.index, ordered=ordered)
+
+        if isinstance(fct, pd.Series):
+            return pd.Series(cat)
+
+        return cat
 
 
 # fct_reorder -----------------------------------------------------------------

--- a/siuba/dply/forcats.py
+++ b/siuba/dply/forcats.py
@@ -245,6 +245,7 @@ def fct_collapse(fct, recat, group_other = None) -> pd.Categorical:
         a list of existing categories, to be given the same name.
     group_other :
         An optional string, specifying what all other categories should be named.
+        This will always be the last category level in the result.
 
     Notes
     -----
@@ -293,11 +294,22 @@ def fct_collapse(fct, recat, group_other = None) -> pd.Categorical:
                 cat_to_new[k] = k
 
     # map from old cat to new code ----
+
     # calculate new codes
     ordered_cats = {new: True for old, new in cat_to_new.items()}
 
+    # move the other group to last in the ordered set
+    if group_other is not None:
+        try:
+            del ordered_cats[group_other]
+            ordered_cats[group_other] = True
+        except KeyError:
+            pass
+
+    # map new category name to code
     new_cat_set = {k: ii for ii, k in enumerate(ordered_cats)}
 
+    # at this point, we need remap codes to the other category
     # make an array, where the index is old code + 1 (so missing val index is 0)
     old_code_to_new = np.array(
             [-1] + [new_cat_set[new_cat] for new_cat in cat_to_new.values()]

--- a/siuba/dply/forcats.py
+++ b/siuba/dply/forcats.py
@@ -108,8 +108,8 @@ def fct_infreq(fct, ordered=None):
     Examples
     --------
 
-    >>> fct_infreq(["c", "a", "c", "b", "a"])
-    ['c', 'a', 'c', 'b', 'a']
+    >>> fct_infreq(["c", "a", "c", "c", "a", "b"])
+    ['c', 'a', 'c', 'c', 'a', 'b']
     Categories (3, object): ['c', 'a', 'b']
 
     """

--- a/siuba/dply/forcats.py
+++ b/siuba/dply/forcats.py
@@ -146,28 +146,37 @@ def fct_infreq(fct, ordered=None):
 def fct_reorder(fct, x, func = np.median, desc = False) -> pd.Categorical:
     """Return copy of fct, with categories reordered according to values in x.
     
-    Arguments:
-        fct: a pandas.Categorical, or array(-like) used to create one.
-        x: values used to reorder categorical. Must be same length as fct.
-        func: function run over all values within a level of the categorical.
-        desc: whether to sort in descending order.
+    Parameters
+    ----------
+    fct :
+        A pandas.Categorical, or array(-like) used to create one.
+    x :
+        Values used to reorder categorical. Must be same length as fct.
+    func :
+        Function run over all values within a level of the categorical.
+    desc :
+        Whether to sort in descending order.
 
-    Notes that NaN categories can't be ordered. When func returns NaN, sorting
+    Notes
+    -----
+    NaN categories can't be ordered. When func returns NaN, sorting
     is always done with NaNs last.
 
 
-    Examples:
-        >>> fct_reorder(['a', 'a', 'b'], [4, 3, 2])
-        ['a', 'a', 'b']
-        Categories (2, object): ['b', 'a']
+    Examples
+    --------
 
-        >>> fct_reorder(['a', 'a', 'b'], [4, 3, 2], desc = True)
-        ['a', 'a', 'b']
-        Categories (2, object): ['a', 'b']
+    >>> fct_reorder(['a', 'a', 'b'], [4, 3, 2])
+    ['a', 'a', 'b']
+    Categories (2, object): ['b', 'a']
 
-        >>> fct_reorder(['x', 'x', 'y'], [4, 0, 2], np.max)
-        ['x', 'x', 'y']
-        Categories (2, object): ['y', 'x']
+    >>> fct_reorder(['a', 'a', 'b'], [4, 3, 2], desc = True)
+    ['a', 'a', 'b']
+    Categories (2, object): ['a', 'b']
+
+    >>> fct_reorder(['x', 'x', 'y'], [4, 0, 2], np.max)
+    ['x', 'x', 'y']
+    Categories (2, object): ['y', 'x']
 
     """
 
@@ -187,18 +196,22 @@ def fct_reorder(fct, x, func = np.median, desc = False) -> pd.Categorical:
 def fct_recode(fct, recat=None, **kwargs) -> pd.Categorical:
     """Return copy of fct with renamed categories.
 
-    Arguments:
-        fct: a pandas.Categorical, or array(-like) used to create one. 
-        **kwargs: arguments of form new_name = old_name.
+    Parameters
+    ----------
+    fct :
+        A pandas.Categorical, or array(-like) used to create one. 
+    **kwargs :
+        Arguments of form new_name = old_name.
 
-    Examples:
-        >>> cat = ['a', 'b', 'c']
-        >>> fct_recode(cat, z = 'c')
-        ['a', 'b', 'z']
-        Categories (3, object): ['a', 'b', 'z']
+    Examples
+    --------
+    >>> cat = ['a', 'b', 'c']
+    >>> fct_recode(cat, z = 'c')
+    ['a', 'b', 'z']
+    Categories (3, object): ['a', 'b', 'z']
 
-        # >>> fct_recode(cat, x = 'a', x = 'b')
-        # >>> fct_recode(cat, x = ['a', 'b'])
+    # >>> fct_recode(cat, x = 'a', x = 'b')
+    # >>> fct_recode(cat, x = ['a', 'b'])
         
     """
 
@@ -223,32 +236,38 @@ def fct_recode(fct, recat=None, **kwargs) -> pd.Categorical:
 def fct_collapse(fct, recat, group_other = None) -> pd.Categorical:
     """Return copy of fct with categories renamed. Optionally group all others.
 
-    Arguments:
-        fct: a pandas.Categorical, or array(-like) used to create one.  
-        recat: dictionary of form {new_cat_name: old_cat_name}. old_cat_name may be
-               a list of existing categories, to be given the same name.
-        group_other: an optional string, specifying what all other categories should be named.
+    Parameters
+    ----------
+    fct :
+        A pandas.Categorical, or array(-like) used to create one.  
+    recat :
+        Dictionary of form {new_cat_name: old_cat_name}. old_cat_name may be
+        a list of existing categories, to be given the same name.
+    group_other :
+        An optional string, specifying what all other categories should be named.
 
-    Notes:
-        Resulting levels index is ordered according to the earliest level replaced.
-        If we rename the first and last levels to "c", then "c" is the first level.
+    Notes
+    -----
+    Resulting levels index is ordered according to the earliest level replaced.
+    If we rename the first and last levels to "c", then "c" is the first level.
 
-    Examples:
-        >>> fct_collapse(['a', 'b', 'c'], {'x': 'a'})
-        ['x', 'b', 'c']
-        Categories (3, object): ['x', 'b', 'c']
+    Examples
+    --------
+    >>> fct_collapse(['a', 'b', 'c'], {'x': 'a'})
+    ['x', 'b', 'c']
+    Categories (3, object): ['x', 'b', 'c']
 
-        >>> fct_collapse(['a', 'b', 'c'], {'x': 'a'}, group_other = 'others')
-        ['x', 'others', 'others']
-        Categories (2, object): ['x', 'others']
+    >>> fct_collapse(['a', 'b', 'c'], {'x': 'a'}, group_other = 'others')
+    ['x', 'others', 'others']
+    Categories (2, object): ['x', 'others']
 
-        >>> fct_collapse(['a', 'b', 'c'], {'ab': ['a', 'b']})
-        ['ab', 'ab', 'c']
-        Categories (2, object): ['ab', 'c']
+    >>> fct_collapse(['a', 'b', 'c'], {'ab': ['a', 'b']})
+    ['ab', 'ab', 'c']
+    Categories (2, object): ['ab', 'c']
 
-        >>> fct_collapse(['a', 'b', None], {'a': ['b']})
-        ['a', 'a', NaN]
-        Categories (1, object): ['a']
+    >>> fct_collapse(['a', 'b', None], {'a': ['b']})
+    ['a', 'a', NaN]
+    Categories (1, object): ['a']
 
     """
     if not isinstance(fct, pd.Categorical):
@@ -295,27 +314,37 @@ def fct_collapse(fct, recat, group_other = None) -> pd.Categorical:
 
 @symbolic_dispatch
 def fct_lump(fct, n = None, prop = None, w = None, other_level = "Other", ties = None) -> pd.Categorical:
-    """
-    Arguments:
-        fct: a pandas.Categorical, or array(-like) used to create one.
-        n: number of categories to keep.
-        prop: (not implemented) keep categories that occur prop proportion of the time.
-        w: array of weights corresponding to each value in fct.
-        other_level: name for all lumped together levels.
-        ties: (not implemented) method to use in the case of ties.
+    """Return a copy of fct with categories lumped together.
 
-    Notes:
-        Currently, one of n and prop must be specified.
+    Parameters
+    ----------
+    fct :
+        A pandas.Categorical, or array(-like) used to create one.
+    n :
+        Number of categories to keep.
+    prop :
+        (not implemented) keep categories that occur prop proportion of the time.
+    w :
+        Array of weights corresponding to each value in fct.
+    other_level :
+        Name for all lumped together levels.
+    ties :
+        (not implemented) method to use in the case of ties.
 
-    Examples:
-        >>> fct_lump(['a', 'a', 'b', 'c'], n = 1)
-        ['a', 'a', 'Other', 'Other']
-        Categories (2, object): ['a', 'Other']
+    Notes
+    -----
+    Currently, one of n and prop must be specified.
 
-        # TODO: implement prop arg
-        >>> fct_lump(['a', 'a', 'b', 'b', 'c', 'd'], prop = .2)
-        ['a', 'a', 'b', 'b', 'Other', 'Other']
-        Categories (3, object): ['a', 'b', 'Other']
+    Examples
+    --------
+    >>> fct_lump(['a', 'a', 'b', 'c'], n = 1)
+    ['a', 'a', 'Other', 'Other']
+    Categories (2, object): ['a', 'Other']
+
+    # TODO: implement prop arg
+    >>> fct_lump(['a', 'a', 'b', 'b', 'c', 'd'], prop = .2)
+    ['a', 'a', 'b', 'b', 'Other', 'Other']
+    Categories (3, object): ['a', 'b', 'Other']
         
 
     """
@@ -364,8 +393,28 @@ def _get_values(x):
 def fct_rev(fct) -> pd.Categorical:
     """Return a copy of fct with category level order reversed.next
     
-    Arguments:
-        fct: a pandas.Categorical, or array(-like) used to create one.
+    Parameters
+    ----------
+    fct :
+        A pandas.Categorical, or array(-like) used to create one.
+
+    Examples
+    --------
+    >>> fct = pd.Categorical(["a", "b", "c"])
+    >>> fct
+    ['a', 'b', 'c']
+    Categories (3, object): ['a', 'b', 'c']
+
+    >>> fct_rev(fct)
+    ['a', 'b', 'c']
+    Categories (3, object): ['c', 'b', 'a']
+
+    Note that this function can also accept a list.
+
+    >>> fct_rev(["a", "b", "c"])
+    ['a', 'b', 'c']
+    Categories (3, object): ['c', 'b', 'a']
+
 
     """
 

--- a/siuba/tests/test_dply_forcats.py
+++ b/siuba/tests/test_dply_forcats.py
@@ -120,6 +120,12 @@ def test_fct_collapse_others():
 
     assert_fct_equal(res, dst)
 
+def test_fct_collapse_other_always_last():
+    res = fct_collapse(['a', 'b', 'c'], {'x': 'c'}, group_other = 'others')
+    dst = Categorical(['others', 'others', 'x'], ['x', 'others'])
+
+    assert_fct_equal(res, dst)
+
 def test_fct_collapse_many_to_one():
     res = fct_collapse(['a', 'b', 'c'], {'ab': ['a', 'b']})
     dst = Categorical(['ab', 'ab', 'c'], ['ab', 'c'])

--- a/siuba/tests/test_dply_forcats.py
+++ b/siuba/tests/test_dply_forcats.py
@@ -30,8 +30,8 @@ def test_fct_inorder(x, dst_categories):
 
     res2 = fct_inorder(pd.Series(x))
 
-    assert isinstance(res2, pd.Categorical)
-    assert_fct_equal(res2, dst)
+    assert isinstance(res2, pd.Series)
+    assert_fct_equal(res2.array, dst)
 
     res3 = fct_inorder(pd.Categorical(x))
 
@@ -57,8 +57,8 @@ def test_fct_infreq(x, dst_categories, skip_pd_v1_1):
 
     res2 = fct_infreq(pd.Series(x))
 
-    assert isinstance(res2, pd.Categorical)
-    assert_categorical_equal(res2, dst)
+    assert isinstance(res2, pd.Series)
+    assert_categorical_equal(res2.array, dst)
 
     res3 = fct_infreq(pd.Categorical(x))
 

--- a/siuba/tests/test_dply_forcats.py
+++ b/siuba/tests/test_dply_forcats.py
@@ -75,12 +75,25 @@ def test_fct_reorder_simple():
 
     assert_fct_equal(res, dst)
     
+def test_fct_reorder_simple_upcast():
+    res = fct_reorder(pd.Series(['a', 'a', 'b']), [4, 3, 2])
+    dst = Categorical(['a', 'a', 'b'], ['b', 'a'])
+
+    assert isinstance(res, pd.Series)
+    assert_fct_equal(res.array, dst)
 
 def test_fct_reorder_desc():
     res = fct_reorder(['a', 'a', 'b'], [4, 3, 2], desc = True)
     dst = Categorical(['a', 'a', 'b'], ['a', 'b'])
 
     assert_fct_equal(res, dst)
+
+def test_fct_reorder_desc_upcast():
+    res = fct_reorder(pd.Series(['a', 'a', 'b']), [4, 3, 2], desc = True)
+    dst = Categorical(['a', 'a', 'b'], ['a', 'b'])
+
+    assert isinstance(res, pd.Series)
+    assert_fct_equal(res.array, dst)
 
 def test_fct_reorder_custom_func():
     import numpy as np
@@ -105,6 +118,14 @@ def test_fct_recode_simple():
 
     assert_fct_equal(res, dst)
 
+def test_fct_recode_simple_upcast():
+    ser = pd.Series(['a', 'b', 'c'])
+    res = fct_recode(ser, z = 'c')
+    dst = Categorical(['a', 'b', 'z'], ['a', 'b', 'z'])
+
+    assert isinstance(ser, pd.Series)
+    assert_fct_equal(res.array, dst)
+
 
 # fct_collapse ----------------------------------------------------------------
 
@@ -113,6 +134,13 @@ def test_fct_collapse_simple():
     dst = Categorical(['x', 'b', 'c'], ['x', 'b', 'c'])
 
     assert_fct_equal(res, dst)
+
+def test_fct_collapse_simple_upcast():
+    res = fct_collapse(pd.Series(['a', 'b', 'c']), {'x': 'a'})
+    dst = Categorical(['x', 'b', 'c'], ['x', 'b', 'c'])
+
+    assert isinstance(res, pd.Series)
+    assert_fct_equal(res.array, dst)
 
 def test_fct_collapse_others():
     res = fct_collapse(['a', 'b', 'c'], {'x': 'a'}, group_other = 'others')
@@ -140,6 +168,13 @@ def test_fct_lump_n():
     dst = Categorical(['a', 'a', 'Other', 'Other'], ['a', 'Other'])
 
     assert_fct_equal(res, dst)
+
+def test_fct_lump_n_upcast():
+    res = fct_lump(pd.Series(['a', 'a', 'b', 'c']), n = 1)
+    dst = Categorical(['a', 'a', 'Other', 'Other'], ['a', 'Other'])
+
+    assert isinstance(res, pd.Series)
+    assert_fct_equal(res.array, dst)
 
 def test_fct_lump_prop():
     res = fct_lump(['a', 'a', 'b', 'b', 'c', 'd'], prop = .2)

--- a/siuba/tests/test_dply_forcats.py
+++ b/siuba/tests/test_dply_forcats.py
@@ -39,11 +39,15 @@ def test_fct_inorder(x, dst_categories):
     assert_fct_equal(res3, dst)
 
 
-@pytest.mark.parametrize("x, dst_categories", [
-    (["c", "c", "b", "c", "a", "a", "a"], ["c", "a", "b"]),
-    (["c", "c", "b", "c", "a", "a", "a", None], ["c", "a", "b"])
+@pytest.mark.parametrize("x, dst_categories, skip_pd_v1_1", [
+    (["c", "c", "b", "c", "a", "a"], ["c", "a", "b"], False),              # no ties
+    (["c", "c", "b", "c", "a", "a", "a"], ["c", "a", "b"], True),          # ties
+    (["c", "c", "b", "c", "a", "a", "a", None], ["c", "a", "b"], False)    # None
 ])
-def test_fct_infreq(x, dst_categories):
+def test_fct_infreq(x, dst_categories, skip_pd_v1_1):
+    if pd.__version__.startswith("1.1."):
+        pytest.skip()
+
     dst = pd.Categorical(x, categories=dst_categories)
 
     res1 = fct_infreq(x)

--- a/siuba/tests/test_dply_forcats.py
+++ b/siuba/tests/test_dply_forcats.py
@@ -1,4 +1,7 @@
-from siuba.dply.forcats import fct_reorder, fct_recode, fct_collapse, fct_lump
+import pandas as pd
+import pytest
+
+from siuba.dply.forcats import fct_reorder, fct_recode, fct_collapse, fct_lump, fct_inorder, fct_infreq
 from pandas import Categorical
 
 try:
@@ -10,6 +13,54 @@ except ImportError:
 
 def assert_fct_equal(x, y):
     return assert_categorical_equal(x,  y)
+
+# fct_inorder -----------------------------------------------------------------
+
+@pytest.mark.parametrize("x, dst_categories", [
+    (["c", "a", "c", "b", "b"], ["c", "a", "b"]),
+    (["c", "a", "c", "b", "b", None], ["c", "a", "b"])
+])
+def test_fct_inorder(x, dst_categories):
+    dst = pd.Categorical(x, categories=dst_categories)
+
+    res1 = fct_inorder(x)
+
+    assert isinstance(res1, pd.Categorical)
+    assert_categorical_equal(res1, dst)
+
+    res2 = fct_inorder(pd.Series(x))
+
+    assert isinstance(res2, pd.Categorical)
+    assert_fct_equal(res2, dst)
+
+    res3 = fct_inorder(pd.Categorical(x))
+
+    assert isinstance(res3, pd.Categorical)
+    assert_fct_equal(res3, dst)
+
+
+@pytest.mark.parametrize("x, dst_categories", [
+    (["c", "c", "b", "c", "a", "a", "a"], ["c", "a", "b"]),
+    (["c", "c", "b", "c", "a", "a", "a", None], ["c", "a", "b"])
+])
+def test_fct_infreq(x, dst_categories):
+    dst = pd.Categorical(x, categories=dst_categories)
+
+    res1 = fct_infreq(x)
+
+    assert isinstance(res1, pd.Categorical)
+    assert_categorical_equal(res1, dst)
+
+    res2 = fct_infreq(pd.Series(x))
+
+    assert isinstance(res2, pd.Categorical)
+    assert_categorical_equal(res2, dst)
+
+    res3 = fct_infreq(pd.Categorical(x))
+
+    assert isinstance(res3, pd.Categorical)
+    assert_categorical_equal(res3, dst)
+
 
 
 # fct_reorder -----------------------------------------------------------------


### PR DESCRIPTION
* implements fct_infreq, which returns a categorical w/ categories ordered by frequency counts (highest first).
* implements fct_inorder, which returns a categorical w/ categories in observed-order (first seen first).
* cleans up existing docstrings, formats into numpydoc style.