### PR TITLE
tests(sql): update failing test, due to duckdb change

### DIFF
--- a/siuba/tests/test_sql_misc.py
+++ b/siuba/tests/test_sql_misc.py
@@ -38,7 +38,8 @@ def test_raw_sql_mutate_refer_previous_raise_dberror(backend, skip_backend, df):
     if backend.name == "duckdb":
         # duckdb dialect re-raises the engines exception, which is RuntimeError
         # the expression to know whether we need to create a subquery.
-        exc = RuntimeError
+        import duckdb
+        exc = duckdb.BinderException
     else:
         exc = sqlalchemy.exc.DatabaseError
 


### PR DESCRIPTION
Quick fix. A test (which is actual testing that an error is raised) began failing due to a change in exception types thrown by duckdb.