### PR TITLE
feat(tbl): add tbl function for pandas and sqla

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -2293,6 +2293,7 @@ def _extract_gdf(__data, *args, **kwargs):
 
 
 # tbl ----
+
 from siuba.siu._databackend import SqlaEngine
 
 @singledispatch2((pd.DataFrame, DataFrameGroupBy))
@@ -2312,7 +2313,7 @@ def tbl(src, *args, **kwargs):
 
     A pandas DataFrame is already a table of data, so trivially returns itself.
 
-    >>> tbl(mtcars) is cars
+    >>> tbl(cars) is cars
     True
 
     tbl() is useful for quickly connecting to a SQL database table.
@@ -2321,15 +2322,15 @@ def tbl(src, *args, **kwargs):
     >>> from siuba import count, show_query, collect
 
     >>> engine = create_engine("sqlite:///:memory:")
-    >>> cars.head(2).to_sql("cars", engine, index=False)
+    >>> cars.to_sql("cars", engine, index=False)
 
     >>> tbl_sql_cars = tbl(engine, "cars")
     >>> tbl_sql_cars >> count()
     # Source: lazy query
     # DB Conn: Engine(sqlite:///:memory:)
     # Preview:
-       n
-    0  2
+        n
+    0  32
     # .. may have more rows
 
     When using duckdb, pass a DataFrame as the third argument to operate directly on it:
@@ -2337,8 +2338,8 @@ def tbl(src, *args, **kwargs):
     >>> engine2 = create_engine("duckdb:///:memory:")
     >>> tbl_cars_duck = tbl(engine, "cars", cars.head(2)) 
     >>> tbl_cars_duck >> count() >> collect()
-       n
-    0  2
+        n
+    0  32
 
     """
 
@@ -2360,7 +2361,8 @@ tbl.register(object)
 def _tbl(__data, *args, **kwargs):
     raise NotImplementedError(
         f"Unsupported type {type(__data)}. "
-        "Note that tbl currently cannot be used in a pipe."
+        "Note that tbl currently can be used at the start of a pipe, but not as "
+        "a step in the pipe."
     )
 
 # Install Siu =================================================================

--- a/siuba/siu/_databackend.py
+++ b/siuba/siu/_databackend.py
@@ -1,0 +1,52 @@
+"""
+This module allows you to check types (e.g. using isinstance) without importing them.
+
+Note that this is copied from https://github.com/machow/databackend
+
+"""
+
+import sys
+import importlib
+
+from abc import ABCMeta
+
+
+def _load_class(mod_name: str, cls_name: str):
+    mod = importlib.import_module(mod_name)
+    return getattr(mod, cls_name)
+
+
+class _AbstractBackendMeta(ABCMeta):
+    def __new__(mcls, clsname, bases, attrs):
+        cls = super().__new__(mcls, clsname, bases, attrs)
+        if not hasattr(cls, "_backends"):
+            cls._backends = []
+        return cls
+
+    def register_backend(cls, mod_name: str, cls_name: str):
+        cls._backends.append((mod_name, cls_name))
+        cls._abc_caches_clear()
+
+
+class AbstractBackend(metaclass=_AbstractBackendMeta):
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        for mod_name, cls_name in cls._backends:
+            if mod_name not in sys.modules:
+                # module isn't loaded, so it can't be the subclass
+                # we don't want to import the module to explicitly run the check
+                # so skip here.
+                continue
+            else:
+                target_cls = _load_class(mod_name, cls_name)
+                if issubclass(target_cls, subclass):
+                    return True
+
+        return NotImplemented
+
+
+# Implementations -------------------------------------------------------------
+
+class SqlaEngine(AbstractBackend): pass
+
+SqlaEngine.register_backend("sqlalchemy.engine", "Engine")

--- a/siuba/siu/_databackend.py
+++ b/siuba/siu/_databackend.py
@@ -39,7 +39,7 @@ class AbstractBackend(metaclass=_AbstractBackendMeta):
                 continue
             else:
                 target_cls = _load_class(mod_name, cls_name)
-                if issubclass(target_cls, subclass):
+                if issubclass(subclass, target_cls):
                     return True
 
         return NotImplemented
@@ -49,4 +49,4 @@ class AbstractBackend(metaclass=_AbstractBackendMeta):
 
 class SqlaEngine(AbstractBackend): pass
 
-SqlaEngine.register_backend("sqlalchemy.engine", "Engine")
+SqlaEngine.register_backend("sqlalchemy.engine", "Connectable")

--- a/siuba/sql/verbs.py
+++ b/siuba/sql/verbs.py
@@ -287,7 +287,7 @@ class LazyTbl:
         self.source = sqlalchemy.create_engine(source) if isinstance(source, str) else source
 
         # get dialect name
-        dialect = self.source.url.get_backend_name()
+        dialect = self.source.dialect.name
         self.translator = get_dialect_translator(dialect)
 
         self.tbl = self._create_table(tbl, columns, self.source)


### PR DESCRIPTION
Adds the `dplyr::tbl` function, with support for pandas and sqlalchemy.

TODO:

- [x] : tests
- [x] : docstring
- [x] : add to API docs