### PR TITLE
fix(data): correctly return sql cars data

### DIFF
--- a/siuba/data/__init__.py
+++ b/siuba/data/__init__.py
@@ -40,6 +40,8 @@ def _load_data_cars_sql():
             "cars",
             ["cyl", "mpg", "hp"]
             )
+    
+    return cars_sql
 
 
 def __getattr__(name):


### PR DESCRIPTION
Currently `from siuba.data import cars_sql` is missing a return statement. Quick fix to resolve.