### PR TITLE
fix: across handles sql grouped; handles pandas mutate with aggs

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -133,9 +133,16 @@ def _mutate_cols(__data, args, kwargs):
         if not isinstance(res_arg, pd.DataFrame):
             raise NotImplementedError("Only across() can be used as positional argument.")
 
+        # unpack result
+        is_scalar = len(res_arg) == 1
+
         for col_name, col_ser in res_arg.items():
             # need to put on the frame so subsequent args, kwargs can use
-            df_tmp[col_name] = col_ser
+            if is_scalar:
+                df_tmp.loc[:, col_name] = col_ser.iloc[0]
+            else:
+                df_tmp.loc[:, col_name] = col_ser.array
+
             result_names[col_name] = True
 
     for col_name, expr in kwargs.items():

--- a/siuba/tests/test_verb_across.py
+++ b/siuba/tests/test_verb_across.py
@@ -172,7 +172,7 @@ def test_across_in_mutate_grouped_equiv_ungrouped(backend, df):
     assert_equal_query2(ungroup(g_res), collect(dst))
 
 
-def test_across_in_mutate_grouped(backend):
+def test_across_in_mutate_grouped_agg(backend):
     df = pd.DataFrame({"x": [1, 2, 3], "y": [7, 8, 9], "g": [1, 1, 2]})
     src = backend.load_df(df)
     g_src = group_by(src, "g")
@@ -184,6 +184,18 @@ def test_across_in_mutate_grouped(backend):
     assert_grouping_names(g_res, ["g"])
     assert_equal_query2(ungroup(g_res), ungroup(dst))
 
+
+def test_across_in_mutate_grouped_transform(backend):
+    df = pd.DataFrame({"x": [1, 2, 3], "y": [7, 8, 9], "g": [1, 1, 2]})
+    src = backend.load_df(df)
+    g_src = group_by(src, "g")
+
+    expr_across = across(_, _[_.x, _.y], Fx.rank())
+    g_res = mutate(g_src, expr_across)
+    dst = pd.DataFrame({"x": [1., 2, 1], "y": [1., 2, 1], "g": [1, 1, 2]})
+
+    assert_grouping_names(g_res, ["g"])
+    assert_equal_query2(ungroup(g_res), dst)
 
 def test_across_in_summarize(backend, df):
     src = backend.load_df(df)


### PR DESCRIPTION
This PR provides two fixes for `across()`

* fix(sql): `across()` now currently sets the OVER clause when LazyTbl is grouped.
* fix(pandas): `across()` now correctly handles aggregates inside a mutate. Previously, it was screwing up the placement of the result by assigning using the index, and not broadcasting.

```python
from siuba.data import cars
from siuba import across, Fx, mutate, head

cars.groupby("cyl") >> mutate(across(_[_.hp, _.mpg], Fx.mean())) >> head()
```

```
   cyl        mpg          hp
0    6  19.742857  122.285714
1    6  19.742857  122.285714
2    4  26.663636   82.636364
3    6  19.742857  122.285714
4    8  15.100000  209.214286
```