### PR TITLE
ci: remove doc publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,60 +144,6 @@ jobs:
         run: |
           make docs-build
 
-      # push to netlify -------------------------------------------------------
-
-      # set release name ----
-
-      - name: Configure pull release name
-        if: ${{github.event_name == 'pull_request'}}
-        run: |
-          echo "RELEASE_NAME=pr-${PR_NUMBER}" >> $GITHUB_ENV
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-      - name: Configure branch release name
-        if: ${{github.event_name != 'pull_request'}}
-        run: |
-          # use branch name, but replace slashes. E.g. feat/a -> feat-a
-          echo "RELEASE_NAME=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
-
-      # deploy ----
-
-      - name: Create Github Deployment
-        uses: bobheadxi/deployments@v0.4.3
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.RELEASE_NAME }}
-          ref: ${{ github.head_ref }}
-          transient: true
-          logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-
-      - name: Netlify docs preview
-        run: |
-          npm install -g netlify-cli
-          # push main branch to production, others to preview --
-          if [ "${ALIAS}" == "main" ]; then
-            netlify deploy --dir=docs/_build/html --prod
-          else
-            netlify deploy --dir=docs/_build/html --alias="${ALIAS}"
-          fi
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          ALIAS: ${{ steps.deployment.outputs.env }}
-
-      - name: Update Github Deployment
-        uses: bobheadxi/deployments@v0.4.3
-        if: ${{ always() }}
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: 'https://${{ steps.deployment.outputs.env }}--siuba.netlify.app'
-          logs: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-
   deploy:
     name: "Deploy to PyPI"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes publishing siuba docs from this repo, as they are now generated on [machow/siuba.org](https://github.com/machow/siuba.org)