### PR TITLE
fix: summarize raising error when a grouping col is all NA (or mostly NA)

### DIFF
--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -363,9 +363,9 @@ def group_by(__data, *args, add = False, **kwargs):
             # ensures group levels are recalculated if varname was in transmute
             groupings[varname] = varname
 
-        return tmp_df.groupby(list(groupings.values()), dropna=False)
+        return tmp_df.groupby(list(groupings.values()), dropna=False, group_keys=True)
 
-    return tmp_df.groupby(by = by_vars, dropna=False)
+    return tmp_df.groupby(by = by_vars, dropna=False, group_keys=True)
 
 
 @singledispatch2((pd.DataFrame, DataFrameGroupBy))

--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -154,7 +154,7 @@ def _mutate_cols(__data, args, kwargs):
 
 
 def _make_groupby_safe(gdf):
-    return gdf.obj.groupby(gdf.grouper, group_keys=False)
+    return gdf.obj.groupby(gdf.grouper, group_keys=False, dropna=False)
 
 
 MSG_TYPE_ERROR = "The first argument to {func} must be one of: {types}"
@@ -363,9 +363,9 @@ def group_by(__data, *args, add = False, **kwargs):
             # ensures group levels are recalculated if varname was in transmute
             groupings[varname] = varname
 
-        return tmp_df.groupby(list(groupings.values()))
+        return tmp_df.groupby(list(groupings.values()), dropna=False)
 
-    return tmp_df.groupby(by = by_vars)
+    return tmp_df.groupby(by = by_vars, dropna=False)
 
 
 @singledispatch2((pd.DataFrame, DataFrameGroupBy))
@@ -563,6 +563,19 @@ def summarize(__data, *args, **kwargs):
     
 @summarize.register(DataFrameGroupBy)
 def _summarize(__data, *args, **kwargs):
+    if __data.dropna or not __data.group_keys:
+        warnings.warn(
+            f"Grouped data passed to summarize must have dropna=False and group_keys=True."
+            " Regrouping with these arguments set."
+        )
+
+        if __data.grouper.dropna:
+            # will need to recalculate groupings, otherwise it ignores dropna
+            group_cols = [ping.name for ping in __data.grouper.groupings]
+        else:
+            group_cols = __data.grouper.groupings
+        __data = __data.obj.groupby(group_cols, dropna=False, group_keys=True)
+
     df_summarize = summarize.registry[pd.DataFrame]
 
     df = __data.apply(df_summarize, *args, **kwargs)

--- a/siuba/tests/test_sql_misc.py
+++ b/siuba/tests/test_sql_misc.py
@@ -31,8 +31,7 @@ def test_raw_sql_mutate_grouped(backend, df):
             )
 
 
-@pytest.mark.skip_backend("duckdb")       # supported by duckdb
-@pytest.mark.skip_backend("snowflake")    # supported by snowflake
+@pytest.mark.skip_backend("snowflake", "duckdb")    # they support this behavior
 @backend_sql
 def test_raw_sql_mutate_refer_previous_raise_dberror(backend, skip_backend, df):
     exc = sqlalchemy.exc.DatabaseError

--- a/siuba/tests/test_sql_misc.py
+++ b/siuba/tests/test_sql_misc.py
@@ -31,17 +31,11 @@ def test_raw_sql_mutate_grouped(backend, df):
             )
 
 
+@pytest.mark.skip_backend("duckdb")       # supported by duckdb
 @pytest.mark.skip_backend("snowflake")    # supported by snowflake
 @backend_sql
 def test_raw_sql_mutate_refer_previous_raise_dberror(backend, skip_backend, df):
-    # Note: unlikely will be able to support this case. Normally we analyze
-    if backend.name == "duckdb":
-        # duckdb dialect re-raises the engines exception, which is RuntimeError
-        # the expression to know whether we need to create a subquery.
-        import duckdb
-        exc = duckdb.BinderException
-    else:
-        exc = sqlalchemy.exc.DatabaseError
+    exc = sqlalchemy.exc.DatabaseError
 
     with pytest.raises(exc):
         assert_equal_query(

--- a/siuba/tests/test_verb_mutate.py
+++ b/siuba/tests/test_verb_mutate.py
@@ -75,6 +75,17 @@ def test_mutate_reassign_all_cols_keeps_rowsize(dfs):
             data_frame(a = [1,1,1], b = [2,2,2])
             )
 
+
+def test_mutate_grouped_pandas_no_dropna():
+    src = data_frame(x = [1, 2], g = [None, None])
+
+    assert_equal_query(
+        src,
+        group_by(_.g) >> mutate(res = _.x + 1),
+        data_frame(x = [1, 2], g = [None, None], res = [2, 3])
+    )
+
+
 @backend_sql
 def test_mutate_window_funcs(backend):
     data = data_frame(idx = range(0, 4), x = range(1, 5), g = [1,1,2,2])


### PR DESCRIPTION
Addresses #458, #251 by..

* setting `dropna=False, group_keys=True` in group_by.
* having summarize regroup with those arguments if necessary.
* note that mutate sets `group_keys=False` to ensure group columns aren't put on the result twice.