### PR TITLE
draft: first pass at overloading verb_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             python-version: 3.8
             requirements: numpy~=1.22.0 pandas~=1.3.5 SQLAlchemy~=1.4.29 psycopg2-binary~=2.9.3 PyMySQL==1.0.2
           - name: "2022-early dependencies"
-            python-version: 3.10.1
+            python-version: "3.10"
             requirements: numpy~=1.22.0 pandas~=1.3.5 SQLAlchemy~=1.4.29 psycopg2-binary~=2.9.3 PyMySQL==1.0.2
             latest: true
 

--- a/siuba/siu/dispatchers.py
+++ b/siuba/siu/dispatchers.py
@@ -11,6 +11,9 @@ from typing import Callable, overload, TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from functools import _SingleDispatchCallable
 
+    _DispatchDecorator = Callable[[Callable[..., Any]], _SingleDispatchCallable[Any]]
+    _DispatchType = type[Any] | tuple[type[Any]]
+
 
 def _dispatch_not_impl(func_name):
     def f(x, *args, **kwargs):
@@ -128,10 +131,10 @@ def register_pipe_call(f):
 # option: no args, custom dispatch (e.g. register NoArgs)
 # strips symbols
 @overload
-def verb_dispatch(cls) -> Callable[[Callable[..., Any]], _SingleDispatchCallable[Any]]:
+def verb_dispatch(cls: "_DispatchType") -> "_DispatchDecorator":
     ...
 @overload
-def verb_dispatch(cls, f: Callable) -> _SingleDispatchCallable[Any]:
+def verb_dispatch(cls: "_DispatchType", f: Callable) -> "_SingleDispatchCallable[Any]":
     ...
 def verb_dispatch(cls, f = None):
     """Wrap singledispatch. Making sure to keep its attributes on the wrapper.

--- a/siuba/siu/dispatchers.py
+++ b/siuba/siu/dispatchers.py
@@ -1,12 +1,16 @@
 # symbolic dispatch wrapper ---------------------------------------------------
 
-from functools import singledispatch, update_wrapper, wraps
-import inspect
+from functools import singledispatch, wraps, partial
 
-from .calls import Call, FuncArg, MetaArg, Lazy, PipeCall, _Isolate
+from .calls import Call, FuncArg, MetaArg, PipeCall, _Isolate
 from .symbolic import Symbolic, create_sym_call, strip_symbolic
 
-from typing import Callable
+from typing import Callable, overload, TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from functools import _SingleDispatchCallable
+
 
 def _dispatch_not_impl(func_name):
     def f(x, *args, **kwargs):
@@ -123,6 +127,12 @@ def register_pipe_call(f):
 
 # option: no args, custom dispatch (e.g. register NoArgs)
 # strips symbols
+@overload
+def verb_dispatch(cls) -> Callable[[Callable[..., Any]], _SingleDispatchCallable[Any]]:
+    ...
+@overload
+def verb_dispatch(cls, f: Callable) -> _SingleDispatchCallable[Any]:
+    ...
 def verb_dispatch(cls, f = None):
     """Wrap singledispatch. Making sure to keep its attributes on the wrapper.
     
@@ -141,7 +151,7 @@ def verb_dispatch(cls, f = None):
 
     # classic way of allowing args to a decorator
     if f is None:
-        return lambda f: verb_dispatch(cls, f)
+        return partial(verb_dispatch, cls)
 
     # initially registers func for object, so need to change to pd.DataFrame
     dispatch_func = singledispatch(f)


### PR DESCRIPTION
Addresses #465, #418.

* Annotates the return type for verb_dispatch as functools._SingleDispatchCallable, so it reflects the behavior of something wrapped in `@singledispatch`.

Need to remove pylance / mypy type checking errors for code like this:

```python
from siuba import mutate

# Pylance: Expected 1 more positional argument
mutate(a = 1)

@singledispatch
def f(a, b): ...

# No type checking error
f()
```