### PR TITLE
fix(sql): sqlalchemy 2.0 compat imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         # unset doctests for earlier versions of python.
         pytest_flags: ["-o addopts='' -m 'not bigquery and not snowflake'"]
+        requirements:
         include:
           # historical requirements
           - name: "2021-mid dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -n "$REQUIREMENTS" ]; then
             python -m pip install $REQUIREMENTS
-          else
+          fi
           python -m pip install .[dev,test]
           # step to test duckdb
           # TODO: move these requirements into the test matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
-        requirements: ['-r requirements.txt']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         # unset doctests for earlier versions of python.
         pytest_flags: ["-o addopts='' -m 'not bigquery and not snowflake'"]
         include:
           # historical requirements
-          - name: "2020-mid dependencies"
-            python-version: 3.8
-            requirements: numpy~=1.19.1 pandas~=1.2.0 SQLAlchemy~=1.3.18 psycopg2~=2.8.5 PyMySQL==1.0.2
-            pytest_flags: "-o addopts='' -m 'not bigquery and not snowflake'"
           - name: "2021-mid dependencies"
             python-version: 3.8
             requirements: numpy~=1.19.1 pandas~=1.2.0 SQLAlchemy~=1.4.13 psycopg2~=2.8.5 PyMySQL==1.0.2
@@ -49,12 +44,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install $REQUIREMENTS
-          python -m pip install -r requirements-test.txt
+          python -m pip install $REQUIREMENTS 
+          python -m pip install .[dev,test]
           # step to test duckdb
           # TODO: move these requirements into the test matrix
           pip install duckdb_engine
-          python -m pip install .
         env:
           REQUIREMENTS: ${{ matrix.requirements }}
       - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -n "$REQUIREMENTS" ]; then
             python -m pip install $REQUIREMENTS
           fi
-          python -m pip install .[dev,test]
+          python -m pip install .[test,docs]
           # step to test duckdb
           # TODO: move these requirements into the test matrix
           pip install duckdb_engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         # unset doctests for earlier versions of python.
-        pytest_flags: ["-o addopts='' -m 'not bigquery and not snowflake'"]
+        pytest_flags: ["-v -o addopts='' -m 'not bigquery and not snowflake'"]
         requirements: [""]
         include:
           # historical requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         # unset doctests for earlier versions of python.
         pytest_flags: ["-o addopts='' -m 'not bigquery and not snowflake'"]
-        requirements: ""
+        requirements: [""]
         include:
           # historical requirements
           - name: "2021-mid dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install $REQUIREMENTS 
+          if [ -n "$REQUIREMENTS" ]; then
+            python -m pip install $REQUIREMENTS
+          else
           python -m pip install .[dev,test]
           # step to test duckdb
           # TODO: move these requirements into the test matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         # unset doctests for earlier versions of python.
         pytest_flags: ["-o addopts='' -m 'not bigquery and not snowflake'"]
-        requirements: []
+        requirements: ""
         include:
           # historical requirements
           - name: "2021-mid dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             python-version: 3.8
             requirements: numpy~=1.22.0 pandas~=1.3.5 SQLAlchemy~=1.4.29 psycopg2-binary~=2.9.3 PyMySQL==1.0.2
           - name: "2022-early dependencies"
-            python-version: 3.10.1
+            python-version: "3.10"
             requirements: numpy~=1.22.0 pandas~=1.3.5 SQLAlchemy~=1.4.29 psycopg2-binary~=2.9.3 PyMySQL==1.0.2
             latest: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -n "$REQUIREMENTS" ]; then
-            python -m pip install $REQUIREMENTS
+            python -m pip install $REQUIREMENTS '.[test,docs]'
+          else
+            python -m pip install '.[test,docs]'
           fi
-          python -m pip install .[test,docs]
           # step to test duckdb
           # TODO: move these requirements into the test matrix
           pip install duckdb_engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         # unset doctests for earlier versions of python.
         pytest_flags: ["-o addopts='' -m 'not bigquery and not snowflake'"]
-        requirements:
+        requirements: []
         include:
           # historical requirements
           - name: "2021-mid dependencies"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ test:
 	pytest siuba/
 
 test-travis:
-	py.test --nbval-lax $(filter-out %postgres.ipynb, $(NOTEBOOK_TESTS))
 	pytest $(PYTEST_FLAGS) siuba/
 
 examples/%.ipynb:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.1
-pandas==1.2.0
+pandas==1.2.5
 psycopg2==2.8.5
 PyMySQL==1.0.2
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/machow/siuba',
     keywords=['package', ],
     install_requires=[
-        "pandas>=0.24.0",
+        "pandas>=0.24.0,<2.1.0",
         "numpy>=1.12.0",
         "SQLAlchemy>=1.2.19",
         "PyYAML>=3.0.0"
@@ -41,7 +41,7 @@ setup(
             "duckdb_engine",
             # duckdb 0.8.0 has a bug which always errors for pandas v2+
             # it's been fixed, but we need to pin until duckdb v0.9.0
-            "duckdb<0.8.1",
+            "duckdb",
         ],
         "docs": [
             "plotnine",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             "duckdb_engine",
             # duckdb 0.8.0 has a bug which always errors for pandas v2+
             # it's been fixed, but we need to pin until duckdb v0.9.0
-            "duckdb<0.8.0",
+            "duckdb<0.8.1",
         ],
         "docs": [
             "plotnine",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,13 @@ setup(
         "test": [
             "pytest",
             "hypothesis",
+            "IPython",
+            "pymysql",
+            "psycopg2-binary",
+            "duckdb_engine",
+            # duckdb 0.8.0 has a bug which always errors for pandas v2+
+            # it's been fixed, but we need to pin until duckdb v0.9.0
+            "duckdb<0.8.0",
         ],
         "docs": [
             "plotnine",

--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -2607,7 +2607,6 @@ def tbl(src, *args, **kwargs):
 
     return src
 
-
 @tbl.register
 def _tbl_sqla(src: SqlaEngine, table_name, columns=None):
     from siuba.sql import LazyTbl
@@ -2623,6 +2622,16 @@ def _tbl_sqla(src: SqlaEngine, table_name, columns=None):
 
 @tbl.register(object)
 def _tbl(__data, *args, **kwargs):
+    # sqlalchemy v2 does not have MockConnection inherit from anything
+    # even though it is a mock :/.
+    try:
+        from sqlalchemy.engine.mock import MockConnection
+
+        if isinstance(__data, MockConnection):
+            return tbl.dispatch(SqlaEngine)(__data, *args, **kwargs)
+    except ImportError:
+        pass
+
     raise NotImplementedError(
         f"Unsupported type {type(__data)}. "
         "Note that tbl currently can be used at the start of a pipe, but not as "

--- a/siuba/dply/verbs.py
+++ b/siuba/dply/verbs.py
@@ -2573,7 +2573,7 @@ def tbl(src, *args, **kwargs):
     >>> from siuba import count, show_query, collect
 
     >>> engine = create_engine("sqlite:///:memory:")
-    >>> cars.to_sql("cars", engine, index=False)
+    >>> _rows = cars.to_sql("cars", engine, index=False)
 
     >>> tbl_sql_cars = tbl(engine, "cars")
     >>> tbl_sql_cars >> count()

--- a/siuba/experimental/pivot/sql_pivot_wide.py
+++ b/siuba/experimental/pivot/sql_pivot_wide.py
@@ -125,7 +125,7 @@ def _pivot_wider_spec(
         when_clause = sql.and_(sel_cols[k] == row[k] for k in name_vars)
         when_then = (when_clause, sel_cols[row[".value"]])
 
-        col = values_fn(dispatch_cls(), _sql_case(when_then))
+        col = values_fn(dispatch_cls(), _sql_case([when_then]))
 
         wide_name_cols.append(col)
 

--- a/siuba/ops/support/base.py
+++ b/siuba/ops/support/base.py
@@ -148,7 +148,7 @@ pandas_methods = pd.DataFrame(read_pandas_ops())
 
 wide_backends = (
         pd.concat([sql_methods, pandas_methods])
-        .pivot("full_name", "backend", "metadata")
+        .pivot(index="full_name", columns="backend", values="metadata")
         )
 
 full_methods = methods.merge(wide_backends, how = "left", on = "full_name")

--- a/siuba/sql/across.py
+++ b/siuba/sql/across.py
@@ -6,6 +6,7 @@ from siuba.siu.visitors import CallListener
 
 from .backend import LazyTbl
 from .utils import _sql_select, _sql_column_collection
+from .translate import ColumnCollection
 
 from sqlalchemy import sql
 
@@ -39,13 +40,13 @@ def _across_lazy_tbl(__data: LazyTbl, cols, fns, names: "str | None" = None) -> 
     #return __data.append_op(_sql_select(res_cols))
 
 
-@across.register(sql.base.ImmutableColumnCollection)
+@across.register(ColumnCollection)
 def _across_sql_cols(
-    __data: sql.base.ImmutableColumnCollection,
+    __data: ColumnCollection,
     cols,
     fns,
     names: "str | None" = None
-) -> sql.base.ImmutableColumnCollection:
+) -> ColumnCollection:
 
     lazy_tbl = ctx_verb_data.get()
     window = ctx_verb_window.get()

--- a/siuba/sql/backend.py
+++ b/siuba/sql/backend.py
@@ -9,7 +9,7 @@ translate.py handles translating column operations.
 
 import warnings
 
-from .translate import CustomOverClause
+from .translate import CustomOverClause, ColumnCollection
 from .utils import (
     get_dialect_translator,
     _sql_column_collection,
@@ -106,7 +106,7 @@ def replace_call_windows(col_expr, group_by, order_by, window_cte = None):
     raise TypeError(str(type(col_expr)))
 
 
-@replace_call_windows.register(sql.base.ImmutableColumnCollection)
+@replace_call_windows.register(ColumnCollection)
 def _(col_expr, group_by, order_by, window_cte = None):
     all_over_clauses = []
     for col in col_expr:

--- a/siuba/sql/backend.py
+++ b/siuba/sql/backend.py
@@ -315,7 +315,7 @@ class LazyTbl:
 
         return sqlalchemy.Table(
                 table_name,
-                sqlalchemy.MetaData(bind = source),
+                sqlalchemy.MetaData(),
                 *columns,
                 schema = schema,
                 autoload_with = source if not columns else None

--- a/siuba/sql/dialects/base.py
+++ b/siuba/sql/dialects/base.py
@@ -43,6 +43,8 @@ from siuba.sql.translate import (
         FunctionLookupBound
         )
 
+from siuba.sql.utils import SQLA_VERSION
+
 
 # =============================================================================
 # Column data classes 
@@ -65,7 +67,10 @@ def sql_func_diff(_, col, periods = 1):
     raise ValueError("periods argument to sql diff cannot be 0")
 
 def sql_func_floordiv(_, x, y):
-    return sql.cast(sql.func.floor(x / y), sa_types.Integer())
+    if SQLA_VERSION >= (2, 0, 0):
+        return sql.cast(x // y, sa_types.Integer())
+
+    return sql.cast(x / y, sa_types.Integer())
 
 def sql_func_rank(_, col):
     # see https://stackoverflow.com/a/36823637/1144523

--- a/siuba/sql/dialects/base.py
+++ b/siuba/sql/dialects/base.py
@@ -65,7 +65,7 @@ def sql_func_diff(_, col, periods = 1):
     raise ValueError("periods argument to sql diff cannot be 0")
 
 def sql_func_floordiv(_, x, y):
-    return sql.cast(x / y, sa_types.Integer())
+    return sql.cast(sql.func.floor(x / y), sa_types.Integer())
 
 def sql_func_rank(_, col):
     # see https://stackoverflow.com/a/36823637/1144523

--- a/siuba/sql/dialects/duckdb.py
+++ b/siuba/sql/dialects/duckdb.py
@@ -92,6 +92,8 @@ returns_int([
 
 extend_base(
     DuckdbColumn,
+    __floordiv__ = lambda _, x, y: x.op("//")(y),
+    __rfloordiv__ = lambda _, y, x: x.op("//")(y),
     rank = sql_func_rank,
     #quantile = sql_quantile(is_analytic=True),
 )

--- a/siuba/sql/dialects/sqlite.py
+++ b/siuba/sql/dialects/sqlite.py
@@ -8,6 +8,7 @@ from ..translate import (
         annotate,
         wrap_annotate
         )
+from ..utils import SQLA_VERSION
 
 from .base import base_nowin
 #from .postgresql import PostgresqlColumn as SqlColumn, PostgresqlColumnAgg as SqlColumnAgg
@@ -90,7 +91,11 @@ def sql_week_of_year(_, col):
     # adapted from: https://stackoverflow.com/a/15511864
     iso_dow = (fn.strftime("%j", fn.date(col, "-3 days", "weekday 4")) - 1)
 
-    return (iso_dow // 7) + 1
+    if SQLA_VERSION >= (2, 0, 0):
+        # in v2, regular division will cause sqlalchemy to coerce the 7 to a float
+        return (iso_dow // 7) + 1
+
+    return (iso_dow / 7) + 1
 
 
 # misc ------------------------------------------------------------------------

--- a/siuba/sql/dialects/sqlite.py
+++ b/siuba/sql/dialects/sqlite.py
@@ -90,7 +90,7 @@ def sql_week_of_year(_, col):
     # adapted from: https://stackoverflow.com/a/15511864
     iso_dow = (fn.strftime("%j", fn.date(col, "-3 days", "weekday 4")) - 1)
 
-    return (iso_dow / 7) + 1
+    return (iso_dow // 7) + 1
 
 
 # misc ------------------------------------------------------------------------

--- a/siuba/sql/dply/vector.py
+++ b/siuba/sql/dply/vector.py
@@ -1,7 +1,6 @@
 import warnings
 
 from sqlalchemy.sql.elements import ClauseElement 
-from sqlalchemy.sql.base import ImmutableColumnCollection
 from sqlalchemy import sql
 
 from ..translate import (

--- a/siuba/sql/translate.py
+++ b/siuba/sql/translate.py
@@ -53,6 +53,10 @@ class SqlColumn(SqlBase): pass
 class SqlColumnAgg(SqlBase): pass
 
 
+# Columns container ===========================================================
+
+from sqlalchemy.sql import ColumnCollection
+
 # Custom over clause handling  ================================================
 
 from sqlalchemy.sql.elements import Over

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -115,7 +115,9 @@ def _sql_select(columns, *args, **kwargs):
 
 
 def _sql_column_collection(columns):
-    from sqlalchemy.sql.base import ColumnCollection
+    # This function largely handles the removal of ImmutableColumnCollection in
+    # sqlalchemy, in favor of ColumnCollection being immutable.
+    from sqlalchemy.sql.base import ColumnCollection, ImmutableColumnCollection
 
     data = {col.key: col for col in columns}
 

--- a/siuba/sql/utils.py
+++ b/siuba/sql/utils.py
@@ -115,11 +115,13 @@ def _sql_select(columns, *args, **kwargs):
 
 
 def _sql_column_collection(columns):
-    from sqlalchemy.sql.base import ColumnCollection, ImmutableColumnCollection
+    from sqlalchemy.sql.base import ColumnCollection
 
     data = {col.key: col for col in columns}
 
     if is_sqla_12() or is_sqla_13():
+        from sqlalchemy.sql.base import ImmutableColumnCollection
+
         return ImmutableColumnCollection(data, columns)
 
     return ColumnCollection(list(data.items())).as_immutable()

--- a/siuba/sql/verbs/arrange.py
+++ b/siuba/sql/verbs/arrange.py
@@ -1,10 +1,9 @@
-from sqlalchemy.sql.base import ImmutableColumnCollection
-
 from siuba.dply.verbs import arrange, _call_strip_ascending
 from siuba.dply.across import _set_data_context
 
 from ..utils import lift_inner_cols
 from ..backend import LazyTbl
+from ..translate import ColumnCollection
 
 # Helpers ---------------------------------------------------------------------
 
@@ -38,7 +37,7 @@ def _eval_arrange_args(__data, args, cols):
         with _set_data_context(__data, window=True):
             res = new_call(cols)
 
-        if isinstance(res, ImmutableColumnCollection):
+        if isinstance(res, ColumnCollection):
             raise NotImplementedError(
                 f"`arrange()` expression {ii} of {len(args)} returned multiple columns, "
                 "which is currently unsupported."

--- a/siuba/sql/verbs/conditional.py
+++ b/siuba/sql/verbs/conditional.py
@@ -6,9 +6,10 @@ from siuba.dply.verbs import case_when, if_else
 from siuba.siu import Call
 
 from ..backend import LazyTbl
+from ..translate import ColumnCollection
 
 
-@case_when.register(sql.base.ImmutableColumnCollection)
+@case_when.register(ColumnCollection)
 def _case_when(__data, cases):
     # TODO: will need listener to enter case statements, to handle when they use windows
     if isinstance(cases, Call):

--- a/siuba/sql/verbs/conditional.py
+++ b/siuba/sql/verbs/conditional.py
@@ -5,6 +5,7 @@ from sqlalchemy import sql
 from siuba.dply.verbs import case_when, if_else
 from siuba.siu import Call
 
+from ..utils import _sql_case
 from ..backend import LazyTbl
 from ..translate import ColumnCollection
 
@@ -36,7 +37,7 @@ def _case_when(__data, cases):
         else:
             whens.append((expr, val))
 
-    return sql.case(whens, else_ = else_val)
+    return _sql_case(whens, else_ = else_val)
 
 
 @case_when.register(LazyTbl)
@@ -52,4 +53,4 @@ def _case_when(__data, cases):
 @if_else.register(sql.elements.ColumnElement)
 def _if_else(cond, true_vals, false_vals):
     whens = [(cond, true_vals)]
-    return sql.case(whens, else_ = false_vals)
+    return _sql_case(whens, else_ = false_vals)

--- a/siuba/sql/verbs/filter.py
+++ b/siuba/sql/verbs/filter.py
@@ -1,6 +1,7 @@
 from siuba.dply.verbs import filter
 
 from ..backend import LazyTbl
+from ..translate import ColumnCollection
 from ..utils import _sql_select
 
 from sqlalchemy import sql
@@ -33,7 +34,7 @@ def _filter(__data, *args):
                         window_cte = win_sel
                         )
 
-                if isinstance(col_expr, sql.base.ImmutableColumnCollection):
+                if isinstance(col_expr, ColumnCollection):
                     conds.extend(col_expr)
                 else:
                     conds.append(col_expr)

--- a/siuba/sql/verbs/mutate.py
+++ b/siuba/sql/verbs/mutate.py
@@ -128,6 +128,6 @@ def _transmute(__data, *args, **kwargs):
     cols_to_keep = [*missing, *result_names]
 
     columns = lift_inner_cols(sel)
-    sel_stripped = sel.with_only_columns([columns[k] for k in cols_to_keep])
+    sel_stripped = _sql_with_only_columns(sel, [columns[k] for k in cols_to_keep])
 
     return __data.append_op(sel_stripped)

--- a/siuba/sql/verbs/select.py
+++ b/siuba/sql/verbs/select.py
@@ -5,7 +5,7 @@ from siuba.dply.verbs import simple_varname
 from pandas import Series
 
 from ..backend import LazyTbl, _warn_missing
-from ..utils import lift_inner_cols
+from ..utils import lift_inner_cols, _sql_with_only_columns
 
 
 @select.register(LazyTbl)
@@ -38,7 +38,7 @@ def _select(__data, *args, **kwargs):
         col_list.append(col if v is None else col.label(v))
 
     return __data.append_op(
-        last_sel.with_only_columns(col_list),
+        _sql_with_only_columns(last_sel, col_list),
         group_by = group_keys
     )
 
@@ -58,7 +58,7 @@ def _rename(__data, **kwargs):
 
     labs = [c.label(old_to_new[k]) if k in old_to_new else c for k,c in columns.items()]
 
-    new_sel = sel.with_only_columns(labs)
+    new_sel = _sql_with_only_columns(sel, labs)
 
     missing_groups, group_keys = _select_group_renames(old_to_new, __data.group_by)
 

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -266,7 +266,7 @@ def copy_to_sql(df, name, engine):
     if isinstance(engine, str):
         engine = sqla.create_engine(engine)
 
-    bool_cols = [k for k, v in df.iteritems() if v.dtype.kind == "b"]
+    bool_cols = [k for k, v in df.items() if v.dtype.kind == "b"]
     columns = [sqla.Column(name, sqla.types.Boolean) for name in bool_cols]
 
 
@@ -299,7 +299,7 @@ def copy_to_sql(df, name, engine):
     # which mostly works, but returns ints from the query
     table = sqla.Table(
             name,
-            sqla.MetaData(bind = engine),
+            sqla.MetaData(),
             *columns,
             autoload_with = autoload_with
             )

--- a/siuba/tests/helpers.py
+++ b/siuba/tests/helpers.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sqla
 import uuid
+import re
 
 from siuba.sql import LazyTbl
 from siuba.sql.utils import _is_dialect_duckdb
@@ -352,3 +353,13 @@ def backend_pandas(msg):
                 return f(backend, *args, **kwargs)
         return wrapper
     return outer
+
+
+# Versions --------------------------------------------------------------------
+
+re_version=r"(?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)"  
+
+
+sqla_version=tuple(map(int, re.match(re_version, sqla.__version__).groups()))
+pd_version=tuple(map(int, re.match(re_version, pd.__version__).groups()))
+

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -249,10 +249,10 @@ def test_frame_mutate(skip_backend, backend, entry):
     dst['result'] = cast_result_type(entry, backend, dst['result'])
 
     result_type = get_spec_sql_type(entry, backend)
-    if result_type == "variable":
-        kwargs = {"check_dtype": False, "atol": 1e-03}
-    else:
-        kwargs = {}
+
+    # relax dtype checking, since database queries sometimes return
+    # int64 instead of int32, etc..
+    kwargs = {"check_dtype": False, "atol": 1e-03}
 
     assert_equal_query(
             df,

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -1,6 +1,13 @@
 from siuba.siu import Symbolic, strip_symbolic
 from siuba.ops.support import spec
-from .helpers import data_frame, assert_equal_query, backend_pandas, SqlBackend, PandasBackend
+from .helpers import (
+    data_frame,
+    assert_equal_query,
+    backend_pandas,
+    pd_version,
+    SqlBackend,
+    PandasBackend
+)
 import pytest
 # TODO: dot, corr, cov
 
@@ -9,6 +16,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 import numpy as np
 import pandas as pd
 import pkg_resources
+
 
 def get_action_kind(spec_entry):
     return spec_entry["kind"]
@@ -28,6 +36,13 @@ def filter_entry(spec, f):
 SPEC_IMPLEMENTED = filter_entry(spec, lambda k, s: s == "Supported")
 SPEC_NOTIMPLEMENTED = filter_entry(spec, lambda k, s: s != "Supported")
 SPEC_AGG = filter_entry(spec, lambda k, s: k in {"Agg"} and s == "Supported")
+
+REMOVED_IN_PANDAS_V2 = {
+    "week",
+    "weekofyear",
+    "mad",
+}
+
 
 _ = Symbolic()
 
@@ -57,6 +72,11 @@ def assert_src_array_equal(src, dst):
         assert_series_equal(src, dst, check_names = False)
     else:
         assert src == dst
+
+
+def skip_if_removed(entry):
+    if pd_version >= (2, 0, 0) and entry["name"] in REMOVED_IN_PANDAS_V2:
+        pytest.skip()
     
 # Data ========================================================================
 data_dt = data_frame(
@@ -182,6 +202,9 @@ def test_series_against_call(entry):
     # TODO: this test originally was evaluating string representations created
     # by calls. I've changed it to just executing the calls directly.
     # not sure the original intent of the test?
+
+    skip_if_removed(entry)
+
     if entry['kind'] == "window":
         pytest.skip()
 
@@ -199,6 +222,8 @@ def test_series_against_call(entry):
 
 
 def test_frame_expr(entry):
+    skip_if_removed(entry)
+
     # TODO: remove this test, not checking anything new
     df = data[entry['accessor']]
     # TODO: once reading from yaml, no need to repr
@@ -235,6 +260,7 @@ def test_frame_mutate(skip_backend, backend, entry):
     do_test_missing_implementation(entry, backend)
     skip_no_mutate(entry, backend)
 
+    skip_if_removed(entry)
 
     # Prepare input data ------------------------------------------------------
     # case: inputs must be boolean
@@ -274,6 +300,9 @@ def test_frame_mutate(skip_backend, backend, entry):
 
 def test_pandas_grouped_frame_fast_mutate(entry):
     from siuba.experimental.pd_groups.dialect import fast_mutate, DataFrameGroupBy
+
+    skip_if_removed(entry)
+    
     gdf = get_data(entry, DATA).groupby('g')
 
     # Execute mutate ----------------------------------------------------------

--- a/siuba/tests/test_dply_series_methods.py
+++ b/siuba/tests/test_dply_series_methods.py
@@ -325,6 +325,8 @@ def test_pandas_grouped_frame_fast_mutate(entry):
 
 
 def test_frame_summarize(skip_backend, backend, agg_entry):
+    skip_if_removed(agg_entry)
+
     entry = agg_entry
 
     do_test_missing_implementation(entry, backend)
@@ -371,6 +373,9 @@ def test_frame_summarize(skip_backend, backend, agg_entry):
 
 def test_pandas_grouped_frame_fast_summarize(agg_entry):
     from siuba.experimental.pd_groups.dialect import fast_summarize, DataFrameGroupBy
+
+    skip_if_removed(agg_entry)
+
     gdf = get_data(agg_entry, DATA).groupby('g')
 
     # Execute summarize ----------------------------------------------------------

--- a/siuba/tests/test_dply_vector.py
+++ b/siuba/tests/test_dply_vector.py
@@ -10,7 +10,6 @@ import siuba.sql.dply
 from siuba.dply import vector as v
 from datetime import timedelta
 
-from hypothesis import given, settings, example
 from hypothesis.strategies import text, floats, integers
 from hypothesis.extra.pandas import data_frames, column, indexes 
 
@@ -140,33 +139,3 @@ def test_filter_vector(backend, func, simple_data):
             simple_data >> group_by(_.g) >> filter(func),
             check_dtype = False
             )
-
-
-#@given(DATA_SPEC)
-#@settings(max_examples = 50, deadline = 1000)
-#def test_hypothesis_mutate_vector_funcs(backend, data):
-#
-#    df = backend.load_df(data)
-#    
-#    for func in OMNIBUS_VECTOR_FUNCS:
-#        assert_equal_query(
-#                df,
-#                mutate(y = func),
-#                data.assign(y = func),
-#                check_dtype = False
-#                )
-
-
-
-@pytest.mark.parametrize('func', [
-    v.n_distinct(_.x),
-    ])
-@given(DATA_SPEC)
-def test_pandas_only_vector_funcs(func, data):
-    res = mutate(data, y = func)
-    dst = data.assign(y = func)
-
-    assert_frame_equal(res, dst)
-
-
-

--- a/siuba/tests/test_sql_verbs.py
+++ b/siuba/tests/test_sql_verbs.py
@@ -38,8 +38,8 @@ def db():
         result = conn.execute(ins)
 
 
-        ins = users.insert()
-        conn.execute(ins, id=2, name='wendy', fullname='Wendy Williams')
+        ins = users.insert().values(id=2, name='wendy', fullname='Wendy Williams')
+        conn.execute(ins)
 
     yield engine
 


### PR DESCRIPTION
This PR adjusts sqlalchemy imports to work with v2.0. Most of the structure for backwards compat was already in place, so this is hopefully just a few imports.